### PR TITLE
Bacpop 17

### DIFF
--- a/PopPUNK/__init__.py
+++ b/PopPUNK/__init__.py
@@ -3,7 +3,7 @@
 
 '''PopPUNK (POPulation Partitioning Using Nucleotide Kmers)'''
 
-__version__ = '2.4.5'
+__version__ = '2.4.6'
 
 # Minimum sketchlib version
 SKETCHLIB_MAJOR = 1

--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -105,7 +105,7 @@ def assign_query(dbFuncs,
                     save_partial_query_graph) 
     return(isolateClustering)           
 
-def assign_query_hd5(dbFuncs,
+def assign_query_hdf5(dbFuncs,
                  ref_db,
                  qNames,
                  output,

--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -77,7 +77,7 @@ def assign_query(dbFuncs,
                                 use_gpu = gpu_sketch,
                                 deviceid = deviceid)
 
-    isolateClustering = assign_query_hd5(dbFuncs,
+    isolateClustering = assign_query_hdf5(dbFuncs,
                     ref_db,
                     qNames,
                     output,

--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -49,10 +49,89 @@ def assign_query(dbFuncs,
                  gpu_dist,
                  gpu_graph,
                  deviceid,
-                 web,
-                 json_sketch,
                  save_partial_query_graph):
-    """Code for assign query mode. Written as a separate function so it can be called
+    """Code for assign query mode for CLI"""
+
+    createDatabaseDir = dbFuncs['createDatabaseDir']
+    constructDatabase = dbFuncs['constructDatabase']
+    readDBParams = dbFuncs['readDBParams']
+
+    if ref_db == output:
+        sys.stderr.write("--output and --ref-db must be different to "
+                         "prevent overwrite.\n")
+        sys.exit(1)
+    
+    # Find distances to reference db
+    kmers, sketch_sizes, codon_phased = readDBParams(ref_db)
+
+    # construct database
+    createDatabaseDir(output, kmers)
+    qNames = constructDatabase(q_files,
+                                kmers,
+                                sketch_sizes,
+                                output,
+                                threads,
+                                overwrite,
+                                codon_phased = codon_phased,
+                                calc_random = False,
+                                use_gpu = gpu_sketch,
+                                deviceid = deviceid)
+
+    isolateClustering = assign_query_hd5(dbFuncs,
+                    ref_db,
+                    qNames,
+                    output,
+                    qc_dict,
+                    update_db,
+                    write_references,
+                    distances,
+                    threads,
+                    overwrite,
+                    plot_fit,
+                    graph_weights,
+                    max_a_dist,
+                    max_pi_dist,
+                    type_isolate,
+                    model_dir,
+                    strand_preserved,
+                    previous_clustering,
+                    external_clustering,
+                    core,
+                    accessory,
+                    gpu_sketch,
+                    gpu_dist,
+                    gpu_graph,
+                    deviceid,
+                    save_partial_query_graph) 
+    return(isolateClustering)           
+
+def assign_query_hd5(dbFuncs,
+                 ref_db,
+                 qNames,
+                 output,
+                 qc_dict,
+                 update_db,
+                 write_references,
+                 distances,
+                 threads,
+                 overwrite,
+                 plot_fit,
+                 graph_weights,
+                 max_a_dist,
+                 max_pi_dist,
+                 type_isolate,
+                 model_dir,
+                 strand_preserved,
+                 previous_clustering,
+                 external_clustering,
+                 core,
+                 accessory,
+                 gpu_sketch,
+                 gpu_dist,
+                 gpu_graph,
+                 deviceid,
+                 save_partial_query_graph):
+    """Code for assign query mode taking hdf5 as input. Written as a separate function so it can be called
     by web APIs"""
 
     # Modules imported here as graph tool is very slow to load (it pulls in all of GTK?)
@@ -80,10 +159,6 @@ def assign_query(dbFuncs,
     from .utils import update_distance_matrices
     from .utils import createOverallLineage
 
-    from .web import sketch_to_hdf5
-
-    createDatabaseDir = dbFuncs['createDatabaseDir']
-    constructDatabase = dbFuncs['constructDatabase']
     joinDBs = dbFuncs['joinDBs']
     queryDatabase = dbFuncs['queryDatabase']
     readDBParams = dbFuncs['readDBParams']
@@ -115,7 +190,7 @@ def assign_query(dbFuncs,
         prev_clustering = model_prefix
 
     # Find distances to reference db
-    kmers, sketch_sizes, codon_phased = readDBParams(ref_db)
+    kmers = readDBParams(ref_db)[0]
 
     # Iterate through different types of model fit with a refined model when specified
     # Core and accessory assignments use the same model and same overall set of distances
@@ -150,22 +225,7 @@ def assign_query(dbFuncs,
                 sys.exit(1)
             else:
                 rNames = getSeqsInDb(os.path.join(ref_db, os.path.basename(ref_db) + ".h5"))
-        # construct database - use a single database directory for all query outputs
-        if (web and json_sketch is not None):
-            qNames = sketch_to_hdf5(json_sketch, output)
-        elif (fit_type == 'default'):
-            # construct database
-            createDatabaseDir(output, kmers)
-            qNames = constructDatabase(q_files,
-                                        kmers,
-                                        sketch_sizes,
-                                        output,
-                                        threads,
-                                        overwrite,
-                                        codon_phased = codon_phased,
-                                        calc_random = False,
-                                        use_gpu = gpu_sketch,
-                                        deviceid = deviceid)
+                
         if (fit_type == 'default' or (fit_type != 'default' and use_ref_graph)):
             # run query
             qrDistMat = queryDatabase(rNames = rNames,
@@ -610,8 +670,6 @@ def main():
                  args.gpu_dist,
                  args.gpu_graph,
                  args.deviceid,
-                 web=False,
-                 json_sketch=None,
                  save_partial_query_graph=False)
 
     sys.stderr.write("\nDone\n")

--- a/PopPUNK/web.py
+++ b/PopPUNK/web.py
@@ -193,7 +193,7 @@ def sketch_to_hdf5(sketches_dict, output):
                 elif key == "codon_phased":
                     sketches.attrs['codon_phased'] = value
                 elif key == "densified":
-                    sketches.attrs['densified'] = value
+                    pass
                 elif key == "bases":
                     sketch_props.attrs['base_freq'] = value
                 elif key == "bbits":


### PR DESCRIPTION
`assign.py`:
- removed arguments `web` &`json_sketch`
- **assign_query()** now creates the hd5 db and then calls **assign_query_hd5()**, which holds most of the code that was previously in **assign_query()**

`web.py`:
- **sketch_to_hd5()** now accepts multiple json sketches in form of a dictionary
- query names as supplied as dict keys are prefixed with a "query_" to distinguish them from reference samples
- **summarise_clusters()** reflects this change by searching for multiple queries in the result df, clusters and cluster prevalences are returned in lists, and include.txt is created for each cluster separately (not sure if we actually need these)