### PR TITLE
Find BLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,10 @@ set_target_properties("${TARGET_NAME}" PROPERTIES
     SUFFIX "${PYTHON_MODULE_EXTENSION}"
 )
 
+find_package(BLAS REQUIRED)
+
 target_link_libraries("${TARGET_NAME}" PRIVATE pybind11::module Eigen3::Eigen
-                                               z gomp openblas gfortran m dl)
+        z gomp ${BLAS_libraries} gfortran m dl)
 #if(OpenMP_CXX_FOUND)
 #    target_link_libraries("${TARGET_NAME}" PRIVATE OpenMP::OpenMP_CXX)
 #endif()


### PR DESCRIPTION
Find BLAS package instead of only requiring OpenBLAS. Allow other blas provider (mkl, flexiblas, atlas, openblas)

Is OpenBLAS really needed though as no symbols are present and the library is not linked in the end?
