### PR TITLE
Improve manual installation instruction

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,11 +59,13 @@ Clone the code
 You can also clone the github to run the latest version, which is executed by::
 
     git clone https://github.com/bacpop/PopPUNK.git && cd PopPUNK
+    python3 setup.py build
+    python3 setup.py install
     python3 poppunk-runner.py
 
 This will also give access to the :ref:`scripts`.
 
 You will need to install the dependencies yourself (you can still use
-conda or pip for this purpose). See ``environment.yml``.
-
-
+conda or pip for this purpose). See ``environment.yml``::
+    mamba env create -f environment.yml
+    conda activate pp_env


### PR DESCRIPTION
Without
```
python3 setup.py build
python3 setup.py install
```
The wrapper script won't function properly, e.g.
```
Traceback (most recent call last):
  File "/lustre/scratch125/pam/teams/team284/ch31/poppunk_test/PopPUNK/poppunk_assign-runner.py", line 13, in <module>
    main()
  File "/lustre/scratch125/pam/teams/team284/ch31/poppunk_test/PopPUNK/PopPUNK/assign.py", line 151, in main
    from .sketchlib import checkSketchlibLibrary
  File "/lustre/scratch125/pam/teams/team284/ch31/poppunk_test/PopPUNK/PopPUNK/sketchlib.py", line 20, in <module>
    from .utils import readRfile, stderr_redirected
  File "/lustre/scratch125/pam/teams/team284/ch31/poppunk_test/PopPUNK/PopPUNK/utils.py", line 28, in <module>
    import poppunk_refine
ModuleNotFoundError: No module named 'poppunk_refine'
```