### PR TITLE
Poppunk assign fix

### DIFF
--- a/PopPUNK/__init__.py
+++ b/PopPUNK/__init__.py
@@ -3,7 +3,7 @@
 
 '''PopPUNK (POPulation Partitioning Using Nucleotide Kmers)'''
 
-__version__ = '2.6.3'
+__version__ = '2.6.4'
 
 # Minimum sketchlib version
 SKETCHLIB_MAJOR = 2

--- a/PopPUNK/network.py
+++ b/PopPUNK/network.py
@@ -1468,8 +1468,11 @@ def printClusters(G, rlist, outPrefix=None, oldClusterFile=None,
     if oldClusterFile != None:
         oldAllClusters = readIsolateTypeFromCsv(oldClusterFile, mode = 'external', return_dict = False)
         oldClusters = oldAllClusters[list(oldAllClusters.keys())[0]]
-        new_id = len(oldClusters.keys()) + 1 # 1-indexed
-        while new_id in oldClusters:
+        # parse all previously used clusters, including those that are merged
+        parsed_oldClusters = set([int(item) for sublist in (x.split('_') for x in oldClusters) for item in sublist])
+        
+        new_id = max(parsed_oldClusters) + 1 # 1-indexed
+        while new_id in parsed_oldClusters:
             new_id += 1 # in case clusters have been merged
 
         # Samples in previous clustering


### PR DESCRIPTION
Corrects issue where new clusters were incorrectly assigned to previous internal cluster IDs.