### PR TITLE
Improvements to DBSCAN fitting

### DIFF
--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -501,7 +501,7 @@ def main():
                 assignments = model.fit(distMat, args.D, args.min_cluster_prop, args.gpu_model)
             # Run Gaussian model
             elif args.fit_model == "bgmm":
-                model = BGMMFit(output, max_samples = args.model_subsample)
+                model = BGMMFit(output, max_samples = args.model_subsample, max_batch_size = args.assign_subsample)
                 model.set_threads(args.threads)
                 assignments = model.fit(distMat, args.K)
             elif args.fit_model == "refine":

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -591,6 +591,10 @@ def main():
         else:
             assignments = model.assign(distMat)
 
+        # end here if not assigning data
+        if args.no_assign:
+            sys.exit(0)
+
         #******************************#
         #*                            *#
         #* network construction       *#

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -116,6 +116,8 @@ def get_options():
     modelGroup = parser.add_argument_group('Model fit options')
     modelGroup.add_argument('--model-subsample', help='Number of pairwise distances used to fit model [default = 100000]',
                             type=int, default=100000)
+    modelGroup.add_argument('--assign-subsample', help='Number of pairwise distances in each assignment batch [default = 5000]',
+                            type=int, default=5000)
     modelGroup.add_argument('--K', help='Maximum number of mixture components [default = 2]', type=int, default=2)
     modelGroup.add_argument('--D', help='Maximum number of clusters in DBSCAN fitting [default = 100]', type=int, default=100)
     modelGroup.add_argument('--min-cluster-prop', help='Minimum proportion of points in a cluster '
@@ -494,7 +496,7 @@ def main():
         if args.fit_model:
             # Run DBSCAN model
             if args.fit_model == "dbscan":
-                model = DBSCANFit(output, max_samples = args.model_subsample)
+                model = DBSCANFit(output, max_samples = args.model_subsample, max_batch_size = args.assign_subsample)
                 model.set_threads(args.threads)
                 assignments = model.fit(distMat, args.D, args.min_cluster_prop, args.gpu_model)
             # Run Gaussian model

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -123,7 +123,7 @@ def get_options():
                             type=int,
                             default=5000)
     modelGroup.add_argument('--no-assign',
-                            help='Fit the model without assigning all points',
+                            help='Fit the model without assigning all points (only applies to BGMM and DBSCAN models)',
                             default=False,
                             action='store_true')
     modelGroup.add_argument('--K',
@@ -518,7 +518,7 @@ def main():
                 model = DBSCANFit(output,
                                   max_samples = args.model_subsample,
                                   max_batch_size = args.assign_subsample,
-                                  assign_points = args.no_assign)
+                                  assign_points = not args.no_assign)
                 model.set_threads(args.threads)
                 assignments = model.fit(distMat,
                                         args.D,
@@ -529,7 +529,7 @@ def main():
                 model = BGMMFit(output,
                                 max_samples = args.model_subsample,
                                 max_batch_size = args.assign_subsample,
-                                assign_points = args.no_assign)
+                                assign_points = not args.no_assign)
                 model.set_threads(args.threads)
                 assignments = model.fit(distMat,
                                         args.K)

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -125,7 +125,7 @@ def get_options():
     modelGroup.add_argument('--no-assign',
                             help='Fit the model without assigning all points',
                             default=False,
-                            action='store_true'))
+                            action='store_true')
     modelGroup.add_argument('--K',
                             help='Maximum number of mixture components [default = 2]',
                             type=int,

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -182,6 +182,7 @@ def get_options():
     other.add_argument('--threads', default=1, type=int, help='Number of threads to use [default = 1]')
     other.add_argument('--gpu-sketch', default=False, action='store_true', help='Use a GPU when calculating sketches (read data only) [default = False]')
     other.add_argument('--gpu-dist', default=False, action='store_true', help='Use a GPU when calculating distances [default = False]')
+    other.add_argument('--gpu-model', default=False, action='store_true', help='Use a GPU when fitting a model [default = False]')
     other.add_argument('--gpu-graph', default=False, action='store_true', help='Use a GPU when calculating networks [default = False]')
     other.add_argument('--deviceid', default=0, type=int, help='CUDA device ID, if using GPU [default = 0]')
     other.add_argument('--no-plot', help='Switch off model plotting, which can be slow for large datasets',
@@ -495,7 +496,7 @@ def main():
             if args.fit_model == "dbscan":
                 model = DBSCANFit(output, max_samples = args.model_subsample)
                 model.set_threads(args.threads)
-                assignments = model.fit(distMat, args.D, args.min_cluster_prop)
+                assignments = model.fit(distMat, args.D, args.min_cluster_prop, args.gpu_model)
             # Run Gaussian model
             elif args.fit_model == "bgmm":
                 model = BGMMFit(output, max_samples = args.model_subsample)

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -114,6 +114,8 @@ def get_options():
 
     # model fitting
     modelGroup = parser.add_argument_group('Model fit options')
+    modelGroup.add_argument('--model-subsample', help='Number of pairwise distances used to fit model [default = 100000]',
+                            type=int, default=100000)
     modelGroup.add_argument('--K', help='Maximum number of mixture components [default = 2]', type=int, default=2)
     modelGroup.add_argument('--D', help='Maximum number of clusters in DBSCAN fitting [default = 100]', type=int, default=100)
     modelGroup.add_argument('--min-cluster-prop', help='Minimum proportion of points in a cluster '
@@ -491,12 +493,12 @@ def main():
         if args.fit_model:
             # Run DBSCAN model
             if args.fit_model == "dbscan":
-                model = DBSCANFit(output)
+                model = DBSCANFit(output, max_samples = args.model_subsample)
                 model.set_threads(args.threads)
                 assignments = model.fit(distMat, args.D, args.min_cluster_prop)
             # Run Gaussian model
             elif args.fit_model == "bgmm":
-                model = BGMMFit(output)
+                model = BGMMFit(output, max_samples = args.model_subsample)
                 model.set_threads(args.threads)
                 assignments = model.fit(distMat, args.K)
             elif args.fit_model == "refine":

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -114,15 +114,34 @@ def get_options():
 
     # model fitting
     modelGroup = parser.add_argument_group('Model fit options')
-    modelGroup.add_argument('--model-subsample', help='Number of pairwise distances used to fit model [default = 100000]',
-                            type=int, default=100000)
-    modelGroup.add_argument('--assign-subsample', help='Number of pairwise distances in each assignment batch [default = 5000]',
-                            type=int, default=5000)
-    modelGroup.add_argument('--K', help='Maximum number of mixture components [default = 2]', type=int, default=2)
-    modelGroup.add_argument('--D', help='Maximum number of clusters in DBSCAN fitting [default = 100]', type=int, default=100)
-    modelGroup.add_argument('--min-cluster-prop', help='Minimum proportion of points in a cluster '
-                                                        'in DBSCAN fitting [default = 0.0001]', type=float, default=0.0001)
-    modelGroup.add_argument('--threshold', help='Cutoff if using --fit-model threshold', type=float)
+    modelGroup.add_argument('--model-subsample',
+                            help='Number of pairwise distances used to fit model [default = 100000]',
+                            type=int,
+                            default=100000)
+    modelGroup.add_argument('--assign-subsample',
+                            help='Number of pairwise distances in each assignment batch [default = 5000]',
+                            type=int,
+                            default=5000)
+    modelGroup.add_argument('--no-assign',
+                            help='Fit the model without assigning all points',
+                            default=False,
+                            action='store_true'))
+    modelGroup.add_argument('--K',
+                            help='Maximum number of mixture components [default = 2]',
+                            type=int,
+                            default=2)
+    modelGroup.add_argument('--D',
+                            help='Maximum number of clusters in DBSCAN fitting [default = 100]',
+                            type=int,
+                            default=100)
+    modelGroup.add_argument('--min-cluster-prop',
+                            help='Minimum proportion of points in a cluster '
+                                 'in DBSCAN fitting [default = 0.0001]',
+                            type=float,
+                            default=0.0001)
+    modelGroup.add_argument('--threshold',
+                            help='Cutoff if using --fit-model threshold',
+                            type=float)
 
     # model refinement
     refinementGroup = parser.add_argument_group('Refine model options')
@@ -496,14 +515,24 @@ def main():
         if args.fit_model:
             # Run DBSCAN model
             if args.fit_model == "dbscan":
-                model = DBSCANFit(output, max_samples = args.model_subsample, max_batch_size = args.assign_subsample)
+                model = DBSCANFit(output,
+                                  max_samples = args.model_subsample,
+                                  max_batch_size = args.assign_subsample,
+                                  assign_points = args.no_assign)
                 model.set_threads(args.threads)
-                assignments = model.fit(distMat, args.D, args.min_cluster_prop, args.gpu_model)
+                assignments = model.fit(distMat,
+                                        args.D,
+                                        args.min_cluster_prop,
+                                        args.gpu_model)
             # Run Gaussian model
             elif args.fit_model == "bgmm":
-                model = BGMMFit(output, max_samples = args.model_subsample, max_batch_size = args.assign_subsample)
+                model = BGMMFit(output,
+                                max_samples = args.model_subsample,
+                                max_batch_size = args.assign_subsample,
+                                assign_points = args.no_assign)
                 model.set_threads(args.threads)
-                assignments = model.fit(distMat, args.K)
+                assignments = model.fit(distMat,
+                                        args.K)
             elif args.fit_model == "refine":
                 new_model = RefineFit(output)
                 new_model.set_threads(args.threads)

--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -409,7 +409,7 @@ def assign_query_hdf5(dbFuncs,
     model.set_threads(threads)
 
     # Only proceed with a fully-fitted model
-    if not self.fitted or (hasattr(self,'assign_points') and self.assign_points == False):
+    if not model.fitted or (hasattr(model,'assign_points') and model.assign_points == False):
         sys.stderr.write('Cannot assign points with an incompletely-fitted model\n')
         sys.exit(1)
 

--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -408,6 +408,11 @@ def assign_query_hdf5(dbFuncs,
         raise RuntimeError("lineage models cannot be used with --serial")
     model.set_threads(threads)
 
+    # Only proceed with a fully-fitted model
+    if not self.fitted or (hasattr(self,'assign_points') and self.assign_points == False):
+        sys.stderr.write('Cannot assign points with an incompletely-fitted model\n')
+        sys.exit(1)
+
     # Set directories of previous fit
     if previous_clustering is not None:
         prev_clustering = previous_clustering

--- a/PopPUNK/dbscan.py
+++ b/PopPUNK/dbscan.py
@@ -40,7 +40,7 @@ def fitDbScan(X, min_samples, min_cluster_size, cache_out, use_gpu = False):
     try:
         import cudf
         from cuml import cluster
-        import cupy
+        import cupy as cp
         gpu_lib = True
     except ImportError as e:
         gpu_lib = False
@@ -56,6 +56,9 @@ def fitDbScan(X, min_samples, min_cluster_size, cache_out, use_gpu = False):
                                  prediction_data = True,
                                  min_cluster_size = min_cluster_size
                                  ).fit(X)
+      # Number of clusters in labels, ignoring noise if present.
+      labels = hdb.labels_
+      n_clusters = len(cp.unique(labels[labels>-1]))
     else:
       sys.stderr.write('Fitting HDBSCAN model using a CPU\n')
       hdb = hdbscan.HDBSCAN(algorithm='boruvka_balltree',
@@ -65,9 +68,9 @@ def fitDbScan(X, min_samples, min_cluster_size, cache_out, use_gpu = False):
                        prediction_data = True,
                        min_cluster_size = min_cluster_size
                        ).fit(X)
-    # Number of clusters in labels, ignoring noise if present.
-    labels = hdb.labels_
-    n_clusters = len(set(labels)) - (1 if -1 in labels else 0)
+      # Number of clusters in labels, ignoring noise if present.
+      labels = hdb.labels_
+      n_clusters = len(set(labels)) - (1 if -1 in labels else 0)
 
     # return model parameters
     return hdb, labels, n_clusters

--- a/PopPUNK/dbscan.py
+++ b/PopPUNK/dbscan.py
@@ -29,7 +29,7 @@ def fitDbScan(X, min_samples, min_cluster_size, cache_out, use_gpu = False):
             Whether GPU algorithms should be used in DBSCAN fitting
 
     Returns:
-        hdb (hdbscan.HDBSCAN)
+        hdb (hdbscan.HDBSCAN or cuml.cluster.HDBSCAN)
             Fitted HDBSCAN to subsampled data
         labels (list)
             Cluster assignments of each sample
@@ -40,6 +40,7 @@ def fitDbScan(X, min_samples, min_cluster_size, cache_out, use_gpu = False):
     try:
         import cudf
         from cuml import cluster
+        import cupy
         gpu_lib = True
     except ImportError as e:
         gpu_lib = False
@@ -49,14 +50,14 @@ def fitDbScan(X, min_samples, min_cluster_size, cache_out, use_gpu = False):
                                 quit_on_fail = True)
     # set DBSCAN clustering parameters
     if use_gpu:
-      sys.stderr.write('Fitting HDBSCAN model using a GPU')
-      hdb = cluster.HDBSCAN(min_samples = min_samples,
-                                 #core_dist_n_jobs = threads, # may cause error, see #19
+      sys.stderr.write('Fitting HDBSCAN model using a GPU\n')
+      hdb = cluster.hdbscan.HDBSCAN(min_samples = min_samples,
+                                 output_type = 'cupy',
                                  prediction_data = True,
                                  min_cluster_size = min_cluster_size
                                  ).fit(X)
     else:
-      sys.stderr.write('Fitting HDBSCAN model using a CPU')
+      sys.stderr.write('Fitting HDBSCAN model using a CPU\n')
       hdb = hdbscan.HDBSCAN(algorithm='boruvka_balltree',
                        min_samples = min_samples,
                        #core_dist_n_jobs = threads, # may cause error, see #19

--- a/PopPUNK/dbscan.py
+++ b/PopPUNK/dbscan.py
@@ -98,7 +98,7 @@ def evaluate_dbscan_clusters(model):
 
     # evaluate whether maxima of cluster nearest origin do not
     # overlap with minima of cluster furthest from origin
-    if core_minimum_of_between > core_maximum_of_within and \
+    if core_minimum_of_between > core_maximum_of_within or \
         accessory_minimum_of_between > accessory_maximum_of_within:
         indistinct = False
 

--- a/PopPUNK/dbscan.py
+++ b/PopPUNK/dbscan.py
@@ -36,20 +36,10 @@ def fitDbScan(X, min_samples, min_cluster_size, cache_out, use_gpu = False):
         n_clusters (int)
             Number of clusters used
     """
-    # Check on initialisation of GPU libraries and memory
-    try:
-        import cudf
-        from cuml import cluster
-        import cupy as cp
-        gpu_lib = True
-    except ImportError as e:
-        gpu_lib = False
-    # check on GPU
-    use_gpu = check_and_set_gpu(use_gpu,
-                                gpu_lib,
-                                quit_on_fail = True)
     # set DBSCAN clustering parameters
     if use_gpu:
+      from cuml import cluster
+      import cupy as cp
       sys.stderr.write('Fitting HDBSCAN model using a GPU\n')
       hdb = cluster.hdbscan.HDBSCAN(min_samples = min_samples,
                                  output_type = 'cupy',

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -614,7 +614,8 @@ class DBSCANFit(ClusterFit):
              means=self.cluster_means,
              maxs=self.cluster_maxs,
              mins=self.cluster_mins,
-             scale=self.scale)
+             scale=self.scale,
+             use_gpu=self.use_gpu)
             with open(self.outPrefix + "/" + os.path.basename(self.outPrefix) + '_fit.pkl', 'wb') as pickle_file:
                 pickle.dump([self.hdb, self.type], pickle_file)
 
@@ -637,6 +638,8 @@ class DBSCANFit(ClusterFit):
         self.cluster_means = fit_npz['means']
         self.cluster_maxs = fit_npz['maxs']
         self.cluster_mins = fit_npz['mins']
+        self.scale = fit_npz['scale']
+        self.use_gpu = fit_npz['use_gpu']
         self.fitted = True
 
 
@@ -687,7 +690,7 @@ class DBSCANFit(ClusterFit):
         '''Assign the clustering of new samples using :func:`~PopPUNK.dbscan.assign_samples_dbscan`
 
         Args:
-            X (numpy.array)
+            X (numpy.array or cupy.array)
                 Core and accessory distances
             no_scale (bool)
                 Do not scale X

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -472,10 +472,11 @@ class DBSCANFit(ClusterFit):
             (default = 100000)
     '''
 
-    def __init__(self, outPrefix, max_samples = 100000):
+    def __init__(self, outPrefix, max_batch_size = 5000, max_samples = 100000):
         ClusterFit.__init__(self, outPrefix)
         self.type = 'dbscan'
         self.preprocess = True
+        self.max_batch_size = max_batch_size
         self.max_samples = max_samples
 
 
@@ -590,7 +591,7 @@ class DBSCANFit(ClusterFit):
         elif not use_gpu:
             shutil.rmtree(cache_out)
 
-        y = self.assign(X, max_batch_size = self.subsampled_X.shape[0], use_gpu = use_gpu)
+        y = self.assign(X, max_batch_size = self.max_batch_size, use_gpu = use_gpu)
         return y
 
 

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -509,8 +509,13 @@ class DBSCANFit(ClusterFit):
         min_samples = min(max(int(min_cluster_prop * self.subsampled_X.shape[0]), 10),1023)
         min_cluster_size = max(int(0.01 * self.subsampled_X.shape[0]), 10)
 
+        # Convert to cupy if using GPU to avoid implicit numpy conversion below
+        if use_gpu:
+            self.subsampled_X = cp.asarray(self.subsampled_X.shape)
+
         indistinct_clustering = True
         while indistinct_clustering and min_cluster_size >= min_samples and min_samples >= 10:
+            # Fit model
             self.hdb, self.labels, self.n_clusters = fitDbScan(self.subsampled_X,
                                                                 min_samples,
                                                                 min_cluster_size,

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -586,7 +586,7 @@ class DBSCANFit(ClusterFit):
         elif not use_gpu:
             shutil.rmtree(cache_out)
 
-        y = self.assign(X, max_batch_size = max_match_size = self.subsampled_X.shape[0], use_gpu = use_gpu)
+        y = self.assign(X, max_match_size = self.subsampled_X.shape[0], use_gpu = use_gpu)
         return y
 
 

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -552,7 +552,11 @@ class DBSCANFit(ClusterFit):
                       self.cluster_mins[cp.array(i),] = [cp.min(self.subsampled_X[labelled_rows,cp.array([0])]),cp.min(self.subsampled_X[labelled_rows,cp.array([1])])]
                       self.cluster_maxs[cp.array(i),] = [cp.max(self.subsampled_X[labelled_rows,cp.array([0])]),cp.max(self.subsampled_X[labelled_rows,cp.array([1])])]
 
-                  y = self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu = True)
+                  y = self.assign(self.subsampled_X,
+                                  no_scale=True,
+                                  progress=False,
+                                  max_batch_size = self.subsampled_X.shape[0],
+                                  use_gpu = True)
                   
               else:
                   # get within strain cluster
@@ -586,7 +590,7 @@ class DBSCANFit(ClusterFit):
         elif not use_gpu:
             shutil.rmtree(cache_out)
 
-        y = self.assign(X, max_match_size = self.subsampled_X.shape[0], use_gpu = use_gpu)
+        y = self.assign(X, max_batch_size = self.subsampled_X.shape[0], use_gpu = use_gpu)
         return y
 
 

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -527,7 +527,7 @@ class DBSCANFit(ClusterFit):
             if use_gpu:
                 self.use_gpu = True
                 self.subsampled_X = cp.asarray(self.subsampled_X)
-            else
+            else:
                 self.use_gpu = False
 
         indistinct_clustering = True

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -505,7 +505,7 @@ class DBSCANFit(ClusterFit):
 
         # DBSCAN parameters
         cache_out = "./" + self.outPrefix + "_cache"
-        min_samples = max(int(min_cluster_prop * self.subsampled_X.shape[0]), 10)
+        min_samples = min(max(int(min_cluster_prop * self.subsampled_X.shape[0]), 10),1023)
         min_cluster_size = max(int(0.01 * self.subsampled_X.shape[0]), 10)
 
         indistinct_clustering = True

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -524,14 +524,14 @@ class DBSCANFit(ClusterFit):
               if use_gpu:
                   # get within strain cluster
                   self.max_cluster_num = self.labels.max()
-                  self.cluster_means = cupy.full((self.n_clusters,2),0.0,dtype=float)
-                  self.cluster_mins = cupy.full((self.n_clusters,2),0.0,dtype=float)
-                  self.cluster_maxs = cupy.full((self.n_clusters,2),0.0,dtype=float)
+                  self.cluster_means = cp.full((self.n_clusters,2),0.0,dtype=float)
+                  self.cluster_mins = cp.full((self.n_clusters,2),0.0,dtype=float)
+                  self.cluster_maxs = cp.full((self.n_clusters,2),0.0,dtype=float)
 
                   for i in range(self.max_cluster_num+1):
-                      self.cluster_means[i,] = [cupy.mean(self.subsampled_X[self.labels==i,0]),cupy.mean(self.subsampled_X[self.labels==i,1])]
-                      self.cluster_mins[i,] = [cupy.min(self.subsampled_X[self.labels==i,0]),cupy.min(self.subsampled_X[self.labels==i,1])]
-                      self.cluster_maxs[i,] = [cupy.max(self.subsampled_X[self.labels==i,0]),cupy.max(self.subsampled_X[self.labels==i,1])]
+                      self.cluster_means[i,] = [cp.mean(self.subsampled_X[self.labels==i,0]),cp.mean(self.subsampled_X[self.labels==i,1])]
+                      self.cluster_mins[i,] = [cp.min(self.subsampled_X[self.labels==i,0]),cp.min(self.subsampled_X[self.labels==i,1])]
+                      self.cluster_maxs[i,] = [cp.max(self.subsampled_X[self.labels==i,0]),cp.max(self.subsampled_X[self.labels==i,1])]
 
                   y = self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu = True)
                   self.within_label = findWithinLabel(self.cluster_means, y)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -548,9 +548,9 @@ class DBSCANFit(ClusterFit):
 
                   for i in range(self.max_cluster_num+1):
                       labelled_rows = cp.where(self.labels==i,True,False)
-                      self.cluster_means[i,] = [cp.mean(self.subsampled_X[labelled_rows,0]),cp.mean(self.subsampled_X[labelled_rows,1])]
-                      self.cluster_mins[i,] = [cp.min(self.subsampled_X[labelled_rows,0]),cp.min(self.subsampled_X[labelled_rows,1])]
-                      self.cluster_maxs[i,] = [cp.max(self.subsampled_X[labelled_rows,0]),cp.max(self.subsampled_X[labelled_rows,1])]
+                      self.cluster_means[i,] = [cp.mean(self.subsampled_X[labelled_rows,cp.array([0])]),cp.mean(self.subsampled_X[labelled_rows,cp.array([1])])]
+                      self.cluster_mins[i,] = [cp.min(self.subsampled_X[labelled_rows,cp.array([0])]),cp.min(self.subsampled_X[labelled_rows,cp.array([1])])]
+                      self.cluster_maxs[i,] = [cp.max(self.subsampled_X[labelled_rows,cp.array([0])]),cp.max(self.subsampled_X[labelled_rows,cp.array([1])])]
 
                   y = self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu = True)
                   

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -472,13 +472,13 @@ class DBSCANFit(ClusterFit):
             (default = 100000)
     '''
 
-    def __init__(self, outPrefix, max_batch_size = 5000, max_samples = 100000):
+    def __init__(self, outPrefix, use_gpu = False, max_batch_size = 5000, max_samples = 100000):
         ClusterFit.__init__(self, outPrefix)
         self.type = 'dbscan'
         self.preprocess = True
         self.max_batch_size = max_batch_size
         self.max_samples = max_samples
-
+        self.use_gpu = use_gpu
 
     def fit(self, X, max_num_clusters, min_cluster_prop, use_gpu = False):
         '''Extends :func:`~ClusterFit.fit`
@@ -663,7 +663,8 @@ class DBSCANFit(ClusterFit):
         plot_dbscan_results(self.subsampled_X * self.scale,
                             self.assign(self.subsampled_X, no_scale=True, progress=False),
                             self.n_clusters,
-                            self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan")
+                            self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan",
+                            self.use_gpu)
 
 
     def assign(self, X, no_scale = False, progress = True, max_batch_size = 5000, use_gpu = False):

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -728,8 +728,11 @@ class DBSCANFit(ClusterFit):
                   start_index = block*block_size
                   end_index = min((block+1)*block_size-1,X.shape[0])
                   sys.stderr.write("Processing rows " + str(start_index) + " to " + str(end_index) + "\n")
-                  y_assignments, y_probabilities = cluster.hdbscan.approximate_predict(self.hdb, X[start_index:end_index,])
-                  y[start_index:end_index] = cp.asnumpy(y_assignments)
+                  # cuml v24.02 always returns numpy therefore make conversion explicit
+                  y[start_index:end_index], y_probabilities = cluster.hdbscan.approximate_predict(self.hdb,
+                                                                                                  X[start_index:end_index,],
+                                                                                                  convert_dtype = True)
+                  del y_probabilities
             else:
               y = np.zeros(X.shape[0], dtype=int)
               n_blocks = (X.shape[0] - 1) // block_size + 1

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -583,7 +583,7 @@ class DBSCANFit(ClusterFit):
             self.fitted = False
             sys.stderr.write("Failed to find distinct clusters in this dataset\n")
             sys.exit(1)
-        else:
+        else if not use_gpu:
             shutil.rmtree(cache_out)
 
         y = self.assign(X)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -691,8 +691,7 @@ class DBSCANFit(ClusterFit):
                 sys.stderr.write("Assigning distances with DBSCAN model\n")
 
             if use_gpu:
-              X_assignments = cluster.hdbscan.approximate_predict(self.hdb, X)
-              y = X_assignments.labels
+              y, y_probabilities = cluster.hdbscan.approximate_predict(self.hdb, X)
             else:
               y = np.zeros(X.shape[0], dtype=int)
               block_size = 5000

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -478,7 +478,7 @@ class DBSCANFit(ClusterFit):
         self.preprocess = True
         self.max_batch_size = max_batch_size
         self.max_samples = max_samples
-        self.use_gpu = use_gpu
+        self.use_gpu = use_gpu # Updated below
 
     def fit(self, X, max_num_clusters, min_cluster_prop, use_gpu = False):
         '''Extends :func:`~ClusterFit.fit`
@@ -525,7 +525,10 @@ class DBSCANFit(ClusterFit):
                                 gpu_lib,
                                 quit_on_fail = True)
             if use_gpu:
+                self.use_gpu = True
                 self.subsampled_X = cp.asarray(self.subsampled_X)
+            else
+                self.use_gpu = False
 
         indistinct_clustering = True
         while indistinct_clustering and min_cluster_size >= min_samples and min_samples >= 10:
@@ -660,11 +663,15 @@ class DBSCANFit(ClusterFit):
             sys.stderr.write("\t" + str(centre) + "\n")
         sys.stderr.write("\n")
 
+        # Convert to numpy for plotting
+        if self.use_gpu:
+            import cupy as cp
+            self.subsampled_X = cp.asnumpy(self.scale)
+
         plot_dbscan_results(self.subsampled_X * self.scale,
                             self.assign(self.subsampled_X, no_scale=True, progress=False),
                             self.n_clusters,
-                            self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan",
-                            self.use_gpu)
+                            self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan")
 
 
     def assign(self, X, no_scale = False, progress = True, max_batch_size = 5000, use_gpu = False):

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -663,6 +663,11 @@ class DBSCANFit(ClusterFit):
             sys.stderr.write("\t" + str(centre) + "\n")
         sys.stderr.write("\n")
 
+        # Harmonise scales
+        if self.use_gpu:
+            import cupy as cp
+            self.scale = cp.asarray(self.scale)
+
         plot_dbscan_results(self.subsampled_X * self.scale,
                             self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu=self.use_gpu),
                             self.n_clusters,

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -289,11 +289,10 @@ class BGMMFit(ClusterFit):
             The output prefix used for reading/writing
         max_samples (int)
             The number of subsamples to fit the model to
-
             (default = 100000)
     '''
 
-    def __init__(self, outPrefix, max_samples = 50000):
+    def __init__(self, outPrefix, max_samples = 100000):
         ClusterFit.__init__(self, outPrefix)
         self.type = 'bgmm'
         self.preprocess = True
@@ -469,7 +468,6 @@ class DBSCANFit(ClusterFit):
             The output prefix used for reading/writing
         max_samples (int)
             The number of subsamples to fit the model to
-
             (default = 100000)
     '''
 

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -673,7 +673,11 @@ class DBSCANFit(ClusterFit):
             self.scale = cp.asarray(self.scale)
 
         plot_dbscan_results(self.subsampled_X * self.scale,
-                            self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu=self.use_gpu),
+                            self.assign(self.subsampled_X,
+                                        max_batch_size = self.max_batch_size,
+                                        no_scale=True,
+                                        progress=False,
+                                        use_gpu=self.use_gpu),
                             self.n_clusters,
                             self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan",
                             self.use_gpu)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -561,12 +561,6 @@ class DBSCANFit(ClusterFit):
                       self.cluster_means[cp.array(i),] = [cp.mean(self.subsampled_X[labelled_rows,cp.array([0])]),cp.mean(self.subsampled_X[labelled_rows,cp.array([1])])]
                       self.cluster_mins[cp.array(i),] = [cp.min(self.subsampled_X[labelled_rows,cp.array([0])]),cp.min(self.subsampled_X[labelled_rows,cp.array([1])])]
                       self.cluster_maxs[cp.array(i),] = [cp.max(self.subsampled_X[labelled_rows,cp.array([0])]),cp.max(self.subsampled_X[labelled_rows,cp.array([1])])]
-
-                  y = self.assign(self.subsampled_X,
-                                  no_scale=True,
-                                  progress=False,
-                                  max_batch_size = self.subsampled_X.shape[0],
-                                  use_gpu = True)
                   
               else:
                   # get within strain cluster
@@ -580,11 +574,12 @@ class DBSCANFit(ClusterFit):
                       self.cluster_mins[i,] = [np.min(self.subsampled_X[self.labels==i,0]),np.min(self.subsampled_X[self.labels==i,1])]
                       self.cluster_maxs[i,] = [np.max(self.subsampled_X[self.labels==i,0]),np.max(self.subsampled_X[self.labels==i,1])]
 
-                  y = self.assign(self.subsampled_X,
-                                  no_scale=True,
-                                  progress=False,
-                                  max_batch_size = self.subsampled_X.shape[0],
-                                  use_gpu = False)
+              # Run assignment
+              y = self.assign(self.subsampled_X,
+                              no_scale=True,
+                              progress=False,
+                              max_batch_size = self.subsampled_X.shape[0],
+                              use_gpu = use_gpu)
               
               # Evaluate clustering
               self.within_label = findWithinLabel(self.cluster_means, y)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -586,7 +586,7 @@ class DBSCANFit(ClusterFit):
         elif not use_gpu:
             shutil.rmtree(cache_out)
 
-        y = self.assign(X)
+        y = self.assign(X, use_gpu = use_gpu)
         return y
 
 

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -586,7 +586,7 @@ class DBSCANFit(ClusterFit):
         elif not use_gpu:
             shutil.rmtree(cache_out)
 
-        y = self.assign(X, use_gpu = use_gpu)
+        y = self.assign(X, max_batch_size = max_match_size = self.subsampled_X.shape[0], use_gpu = use_gpu)
         return y
 
 
@@ -661,7 +661,7 @@ class DBSCANFit(ClusterFit):
                             self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan")
 
 
-    def assign(self, X, no_scale = False, progress = True, use_gpu = False):
+    def assign(self, X, no_scale = False, progress = True, max_batch_size = 5000, use_gpu = False):
         '''Assign the clustering of new samples using :func:`~PopPUNK.dbscan.assign_samples_dbscan`
 
         Args:
@@ -673,6 +673,9 @@ class DBSCANFit(ClusterFit):
             progress (bool)
                 Show progress bar
                 [default = True]
+            max_batch_size (int)
+                Batch size used for GPU assignments
+                [default = 5000]
             use_gpu (bool)
                 Use GPU-enabled algorithms for clustering
                 [default = False]
@@ -692,7 +695,7 @@ class DBSCANFit(ClusterFit):
 
             if use_gpu:
               y = np.zeros(X.shape[0], dtype=int)
-              block_size = 500000
+              block_size = max_batch_size
               n_blocks = (X.shape[0] - 1) // block_size + 1
               for block in range(n_blocks):
                   start_index = block*block_size

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -583,7 +583,7 @@ class DBSCANFit(ClusterFit):
             self.fitted = False
             sys.stderr.write("Failed to find distinct clusters in this dataset\n")
             sys.exit(1)
-        else if not use_gpu:
+        elif not use_gpu:
             shutil.rmtree(cache_out)
 
         y = self.assign(X)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -548,9 +548,9 @@ class DBSCANFit(ClusterFit):
 
                   for i in range(self.max_cluster_num+1):
                       labelled_rows = cp.where(self.labels==i,True,False)
-                      self.cluster_means[i,] = [cp.mean(self.subsampled_X[labelled_rows,cp.array([0])]),cp.mean(self.subsampled_X[labelled_rows,cp.array([1])])]
-                      self.cluster_mins[i,] = [cp.min(self.subsampled_X[labelled_rows,cp.array([0])]),cp.min(self.subsampled_X[labelled_rows,cp.array([1])])]
-                      self.cluster_maxs[i,] = [cp.max(self.subsampled_X[labelled_rows,cp.array([0])]),cp.max(self.subsampled_X[labelled_rows,cp.array([1])])]
+                      self.cluster_means[cp.array(i),] = [cp.mean(self.subsampled_X[labelled_rows,cp.array([0])]),cp.mean(self.subsampled_X[labelled_rows,cp.array([1])])]
+                      self.cluster_mins[cp.array(i),] = [cp.min(self.subsampled_X[labelled_rows,cp.array([0])]),cp.min(self.subsampled_X[labelled_rows,cp.array([1])])]
+                      self.cluster_maxs[cp.array(i),] = [cp.max(self.subsampled_X[labelled_rows,cp.array([0])]),cp.max(self.subsampled_X[labelled_rows,cp.array([1])])]
 
                   y = self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu = True)
                   

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -696,7 +696,7 @@ class DBSCANFit(ClusterFit):
               n_blocks = (X.shape[0] - 1) // block_size + 1
               for block in range(n_blocks):
                   start_index = block*block_size
-                  end_index = max((block+1)*block_size,X.shape[0])
+                  end_index = min((block+1)*block_size-1,X.shape[0])
                   sys.stderr.write("Processing rows " + str(start_index) + " to " + str(end_index) + "\n")
                   y_assignments, y_probabilities = cluster.hdbscan.approximate_predict(self.hdb, X[start_index:end_index,])
                   y[start_index:end_index] = cp.asnumpy(y_assignments)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -663,15 +663,11 @@ class DBSCANFit(ClusterFit):
             sys.stderr.write("\t" + str(centre) + "\n")
         sys.stderr.write("\n")
 
-        # Convert to numpy for plotting
-        if self.use_gpu:
-            import cupy as cp
-            self.subsampled_X = cp.asnumpy(self.scale)
-
         plot_dbscan_results(self.subsampled_X * self.scale,
                             self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu=self.use_gpu),
                             self.n_clusters,
-                            self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan")
+                            self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan",
+                            self.use_gpu)
 
 
     def assign(self, X, no_scale = False, progress = True, max_batch_size = 5000, use_gpu = False):

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -669,7 +669,7 @@ class DBSCANFit(ClusterFit):
             self.subsampled_X = cp.asnumpy(self.scale)
 
         plot_dbscan_results(self.subsampled_X * self.scale,
-                            self.assign(self.subsampled_X, no_scale=True, progress=False),
+                            self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu=self.use_gpu),
                             self.n_clusters,
                             self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan")
 

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -800,6 +800,7 @@ class RefineFit(ClusterFit):
         self.slope = 2
         self.threshold = False
         self.unconstrained = False
+        self.assign_points = True
 
     def fit(self, X, sample_names, model, max_move, min_move, startFile = None, indiv_refine = False,
             unconstrained = False, multi_boundary = 0, score_idx = 0, no_local = False,

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -523,7 +523,7 @@ class DBSCANFit(ClusterFit):
             
               if use_gpu:
                   # get within strain cluster
-                  self.max_cluster_num = int(self.labels.amax()[0])
+                  self.max_cluster_num = int(self.labels.max()[0])
                   self.cluster_means = cp.full((self.n_clusters,2),0.0,dtype=float)
                   self.cluster_mins = cp.full((self.n_clusters,2),0.0,dtype=float)
                   self.cluster_maxs = cp.full((self.n_clusters,2),0.0,dtype=float)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -539,10 +539,6 @@ class DBSCANFit(ClusterFit):
                       self.cluster_maxs[i,] = [cp.max(self.subsampled_X[self.labels==i,0]),cp.max(self.subsampled_X[self.labels==i,1])]
 
                   y = self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu = True)
-                  self.within_label = findWithinLabel(self.cluster_means, y)
-                  self.between_label = findBetweenLabel(y, self.within_label)
-
-                  indistinct_clustering = evaluate_dbscan_clusters(self)
                   
               else:
                   # get within strain cluster
@@ -557,10 +553,11 @@ class DBSCANFit(ClusterFit):
                       self.cluster_maxs[i,] = [np.max(self.subsampled_X[self.labels==i,0]),np.max(self.subsampled_X[self.labels==i,1])]
 
                   y = self.assign(self.subsampled_X, no_scale=True, progress=False, use_gpu = False)
-                  self.within_label = findWithinLabel(self.cluster_means, y)
-                  self.between_label = findBetweenLabel(y, self.within_label)
-
-                  indistinct_clustering = evaluate_dbscan_clusters(self)
+              
+              # Evaluate clustering
+              self.within_label = findWithinLabel(self.cluster_means, y)
+              self.between_label = findBetweenLabel(y, self.within_label)
+              indistinct_clustering = evaluate_dbscan_clusters(self)
 
             # Alter minimum cluster size criterion
             if min_cluster_size < min_samples / 2:

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -523,7 +523,7 @@ class DBSCANFit(ClusterFit):
             
               if use_gpu:
                   # get within strain cluster
-                  self.max_cluster_num = self.labels.max()
+                  self.max_cluster_num = int(self.labels.amax()[0])
                   self.cluster_means = cp.full((self.n_clusters,2),0.0,dtype=float)
                   self.cluster_mins = cp.full((self.n_clusters,2),0.0,dtype=float)
                   self.cluster_maxs = cp.full((self.n_clusters,2),0.0,dtype=float)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -478,7 +478,7 @@ class DBSCANFit(ClusterFit):
         self.max_samples = max_samples
 
 
-    def fit(self, X, max_num_clusters, min_cluster_prop):
+    def fit(self, X, max_num_clusters, min_cluster_prop, use_gpu = False):
         '''Extends :func:`~ClusterFit.fit`
 
         Fits the distances with HDBSCAN and returns assignments by calling
@@ -494,6 +494,8 @@ class DBSCANFit(ClusterFit):
                 Maximum number of clusters in DBSCAN fitting
             min_cluster_prop (float)
                 Minimum proportion of points in a cluster in DBSCAN fitting
+            use_gpu (bool)
+                Whether GPU algorithms should be used in DBSCAN fitting
 
         Returns:
             y (numpy.array)
@@ -508,7 +510,11 @@ class DBSCANFit(ClusterFit):
 
         indistinct_clustering = True
         while indistinct_clustering and min_cluster_size >= min_samples and min_samples >= 10:
-            self.hdb, self.labels, self.n_clusters = fitDbScan(self.subsampled_X, min_samples, min_cluster_size, cache_out)
+            self.hdb, self.labels, self.n_clusters = fitDbScan(self.subsampled_X,
+                                                                min_samples,
+                                                                min_cluster_size,
+                                                                cache_out,
+                                                                use_gpu = use_gpu)
             self.fitted = True # needed for predict
 
             # Test whether model fit contains distinct clusters

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -523,7 +523,7 @@ class DBSCANFit(ClusterFit):
             
               if use_gpu:
                   # get within strain cluster
-                  self.max_cluster_num = int(self.labels.max()[0])
+                  self.max_cluster_num = int(self.labels.max())
                   self.cluster_means = cp.full((self.n_clusters,2),0.0,dtype=float)
                   self.cluster_mins = cp.full((self.n_clusters,2),0.0,dtype=float)
                   self.cluster_maxs = cp.full((self.n_clusters,2),0.0,dtype=float)

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -678,7 +678,7 @@ class DBSCANFit(ClusterFit):
                 Show progress bar
                 [default = True]
             max_batch_size (int)
-                Batch size used for GPU assignments
+                Batch size used for assignments
                 [default = 5000]
             use_gpu (bool)
                 Use GPU-enabled algorithms for clustering
@@ -696,10 +696,12 @@ class DBSCANFit(ClusterFit):
                 scale = self.scale
             if progress:
                 sys.stderr.write("Assigning distances with DBSCAN model\n")
-
+            
+            # Set block size
+            block_size = max_batch_size
+            
             if use_gpu:
               y = np.zeros(X.shape[0], dtype=int)
-              block_size = max_batch_size
               n_blocks = (X.shape[0] - 1) // block_size + 1
               for block in range(n_blocks):
                   start_index = block*block_size
@@ -709,7 +711,6 @@ class DBSCANFit(ClusterFit):
                   y[start_index:end_index] = cp.asnumpy(y_assignments)
             else:
               y = np.zeros(X.shape[0], dtype=int)
-              block_size = 5000
               n_blocks = (X.shape[0] - 1) // block_size + 1
               with SharedMemoryManager() as smm:
                   shm_X = smm.SharedMemory(size = X.nbytes)

--- a/PopPUNK/network.py
+++ b/PopPUNK/network.py
@@ -163,7 +163,7 @@ def checkNetworkVertexCount(seq_list, G, use_gpu):
     if len(networkMissing) > 0:
         sys.stderr.write("ERROR: " + str(len(networkMissing)) + " samples are missing from the final network\n")
         if len(networkMissing) < 10:
-            sys.stderr.write('Missing isolate are: ' + ' '.join(networkMissing))
+            sys.stderr.write('Missing isolates are: ' + ' '.join([seq_list[x] for x in networkMissing]))
         sys.exit(1)
 
 def getCliqueRefs(G, reference_indices = set()):

--- a/PopPUNK/network.py
+++ b/PopPUNK/network.py
@@ -1339,15 +1339,15 @@ def addQueryToNetwork(dbFuncs, rList, qList, G,
 
     return G, qqDistMat
 
-def generate_cugraph(G_df, seq_num, weights = False, renumber = True):
+def generate_cugraph(G_df, max_index, weights = False, renumber = True):
     """Builds cugraph graph to ensure all nodes are included in
     the graph, even if singletons.
 
     Args:
         G_df (cudf)
             cudf data frame containing edge list
-        seq_num (int)
-            The expected number of nodes in the graph
+        max_index (int)
+            The 0-indexed maximum of the node indices
         renumber (bool)
             Whether to renumber the vertices when added to the graph
 
@@ -1356,7 +1356,7 @@ def generate_cugraph(G_df, seq_num, weights = False, renumber = True):
             Dictionary of cluster assignments (keys are sequence names)
     """
     # use self-loop to ensure all nodes are present
-    node_indices = cudf.Series(range(seq_num), dtype = cp.int32)
+    node_indices = cudf.Series(range(seq_num+1), dtype = cp.int32)
     G_self_loop = cudf.DataFrame()
     G_self_loop['source'] = node_indices
     G_self_loop['destination'] = node_indices

--- a/PopPUNK/network.py
+++ b/PopPUNK/network.py
@@ -162,8 +162,11 @@ def checkNetworkVertexCount(seq_list, G, use_gpu):
     networkMissing = set(set(range(len(seq_list))).difference(vertex_list))
     if len(networkMissing) > 0:
         sys.stderr.write("ERROR: " + str(len(networkMissing)) + " samples are missing from the final network\n")
-        if len(networkMissing) < 10:
-            sys.stderr.write('Missing isolates are: ' + ' '.join([seq_list[x] for x in networkMissing]))
+        if len(networkMissing) == 1:
+          sys.stderr.write('Missing isolate is: ' + seq_list[networkMissing[0]] + ' (index ' + str(networkMissing[0]) + ')')
+        elif len(networkMissing) < 10:
+          sys.stderr.write('Missing isolates are: ' + ' '.join([seq_list[x] for x in networkMissing]))
+          sys.stderr.write('These have the indices ' + ' '.join([str(x) for x in networkMissing]))
         sys.exit(1)
 
 def getCliqueRefs(G, reference_indices = set()):

--- a/PopPUNK/network.py
+++ b/PopPUNK/network.py
@@ -163,10 +163,11 @@ def checkNetworkVertexCount(seq_list, G, use_gpu):
     if len(networkMissing) > 0:
         sys.stderr.write("ERROR: " + str(len(networkMissing)) + " samples are missing from the final network\n")
         if len(networkMissing) == 1:
-          sys.stderr.write('Missing isolate is: ' + seq_list[networkMissing[0]] + ' (index ' + str(networkMissing[0]) + ')')
+            missing_isolate_index = networkMissing.pop()
+            sys.stderr.write('Missing isolate is: ' + seq_list[missing_isolate_index] + ' (index ' + str(missing_isolate_index) + ')')
         elif len(networkMissing) < 10:
-          sys.stderr.write('Missing isolates are: ' + ' '.join([seq_list[x] for x in networkMissing]))
-          sys.stderr.write('These have the indices ' + ' '.join([str(x) for x in networkMissing]))
+            sys.stderr.write('Missing isolates are: ' + ' '.join([seq_list[x] for x in networkMissing]))
+            sys.stderr.write('These have the indices ' + ' '.join([str(x) for x in networkMissing]))
         sys.exit(1)
 
 def getCliqueRefs(G, reference_indices = set()):

--- a/PopPUNK/network.py
+++ b/PopPUNK/network.py
@@ -1356,7 +1356,7 @@ def generate_cugraph(G_df, max_index, weights = False, renumber = True):
             Dictionary of cluster assignments (keys are sequence names)
     """
     # use self-loop to ensure all nodes are present
-    node_indices = cudf.Series(range(seq_num+1), dtype = cp.int32)
+    node_indices = cudf.Series(range(max_index+1), dtype = cp.int32)
     G_self_loop = cudf.DataFrame()
     G_self_loop['source'] = node_indices
     G_self_loop['destination'] = node_indices

--- a/PopPUNK/plot.py
+++ b/PopPUNK/plot.py
@@ -182,7 +182,7 @@ def plot_results(X, Y, means, covariances, scale, title, out_prefix):
     plt.savefig(out_prefix + ".png")
     plt.close()
 
-def plot_dbscan_results(X, y, n_clusters, out_prefix):
+def plot_dbscan_results(X, y, n_clusters, out_prefix, use_gpu):
     """Draw a scatter plot (png) to show the DBSCAN model fit
 
     A scatter plot of core and accessory distances, coloured by component
@@ -197,7 +197,15 @@ def plot_dbscan_results(X, y, n_clusters, out_prefix):
             Number of clusters used (excluding noise)
         out_prefix (str)
             Prefix for output file (.png will be appended)
+        use_gpu (bool)
+            Whether model was fitted with GPU-enabled code
     """
+    # Convert data if from GPU
+    if use_gpu:
+        # Convert to numpy for plotting
+        import cupy as cp
+        X = cp.asnumpy(X)
+    
     # Black removed and is used for noise instead.
     unique_labels = set(y)
     colours = [plt.cm.Spectral(each) for each in np.linspace(0, 1, len(unique_labels))]  # changed to work with two clusters

--- a/PopPUNK/plot.py
+++ b/PopPUNK/plot.py
@@ -182,7 +182,7 @@ def plot_results(X, Y, means, covariances, scale, title, out_prefix):
     plt.savefig(out_prefix + ".png")
     plt.close()
 
-def plot_dbscan_results(X, y, n_clusters, out_prefix, use_gpu):
+def plot_dbscan_results(X, y, n_clusters, out_prefix):
     """Draw a scatter plot (png) to show the DBSCAN model fit
 
     A scatter plot of core and accessory distances, coloured by component
@@ -197,15 +197,10 @@ def plot_dbscan_results(X, y, n_clusters, out_prefix, use_gpu):
             Number of clusters used (excluding noise)
         out_prefix (str)
             Prefix for output file (.png will be appended)
-        use_gpu (bool)
-            Whether model was fitted with GPU or not
     """
     # Black removed and is used for noise instead.
     unique_labels = set(y)
-    if use_gpu:
-      colours = [plt.cm.Spectral(each) for each in cp.linspace(0, 1, len(unique_labels))]  # changed to work with two clusters
-    else:
-      colours = [plt.cm.Spectral(each) for each in np.linspace(0, 1, len(unique_labels))]  # changed to work with two clusters
+    colours = [plt.cm.Spectral(each) for each in np.linspace(0, 1, len(unique_labels))]  # changed to work with two clusters
 
     fig=plt.figure(figsize=(11, 8), dpi= 160, facecolor='w', edgecolor='k')
     for k in unique_labels:

--- a/PopPUNK/plot.py
+++ b/PopPUNK/plot.py
@@ -182,7 +182,7 @@ def plot_results(X, Y, means, covariances, scale, title, out_prefix):
     plt.savefig(out_prefix + ".png")
     plt.close()
 
-def plot_dbscan_results(X, y, n_clusters, out_prefix):
+def plot_dbscan_results(X, y, n_clusters, out_prefix, use_gpu):
     """Draw a scatter plot (png) to show the DBSCAN model fit
 
     A scatter plot of core and accessory distances, coloured by component
@@ -197,10 +197,15 @@ def plot_dbscan_results(X, y, n_clusters, out_prefix):
             Number of clusters used (excluding noise)
         out_prefix (str)
             Prefix for output file (.png will be appended)
+        use_gpu (bool)
+            Whether model was fitted with GPU or not
     """
     # Black removed and is used for noise instead.
     unique_labels = set(y)
-    colours = [plt.cm.Spectral(each) for each in np.linspace(0, 1, len(unique_labels))]  # changed to work with two clusters
+    if use_gpu:
+      colours = [plt.cm.Spectral(each) for each in cp.linspace(0, 1, len(unique_labels))]  # changed to work with two clusters
+    else:
+      colours = [plt.cm.Spectral(each) for each in np.linspace(0, 1, len(unique_labels))]  # changed to work with two clusters
 
     fig=plt.figure(figsize=(11, 8), dpi= 160, facecolor='w', edgecolor='k')
     for k in unique_labels:

--- a/PopPUNK/refine.py
+++ b/PopPUNK/refine.py
@@ -42,7 +42,7 @@ from .__main__ import betweenness_sample_default
 from .network import construct_network_from_df, printClusters
 from .network import construct_network_from_edge_list
 from .network import networkSummary
-from .network import add_self_loop
+from .network import generate_cugraph
 
 from .utils import transformLine
 from .utils import decisionBoundary

--- a/PopPUNK/utils.py
+++ b/PopPUNK/utils.py
@@ -8,6 +8,7 @@ import os
 import sys
 # additional
 import pickle
+import multiprocessing
 from collections import defaultdict
 from itertools import chain
 from tempfile import mkstemp
@@ -572,11 +573,12 @@ def check_and_set_gpu(use_gpu, gpu_lib, quit_on_fail = False):
 
     # Set memory management for large networks
     if use_gpu:
+        multiprocessing.set_start_method('spawn', force=True)
         rmm.reinitialize(managed_memory=True)
         if "cupy" in sys.modules:
-            cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+            cupy.cuda.set_allocator(rmm.allocators.cupy.rmm_cupy_allocator)
         if "cuda" in sys.modules:
-            cuda.set_memory_manager(rmm.RMMNumbaManager)
+            cuda.set_memory_manager(rmm.allocators.numba.RMMNumbaManager)
         assert(rmm.is_initialized())
 
     return use_gpu


### PR DESCRIPTION
Motivated by trying to fit a DBSCAN model to a large dataset. Problems were:
- indistinct clustering criterion; this was very strict (separation between within and between strain cluster on both axes required), rejecting some sensible fits; now relaxed (separation only required on one axis) - let me know if you think the stricter option should still be available though a flag, or if you're happy with change across the board
- slow fitting to large datasets; implemented GPU version of DBSCAN, which is fast; the problem is then assigning all distances, which is slow, because the model takes up a lot of GPU memory, and copying over batches of distances into the variable amount of remaining GPU memory (customisable with the new `--assign-subsample` option) negates the speed up of the initial fit
- slow assignment of distances to model fit; this is inefficient, as we typically don't use the assignments of points to the initial model fit, and it takes ages on a large dataset. Instead I have added a `--no-assign` flag, which skips the assignment, labels the model appropriately, and allows a refined model fit that then assigns all points

If you approve these changes conceptually, then I'll add tests and docs. At the moment, local tests fail on the mandrake clustering step - I don't know if these are related to the [failing tests for mandrake](https://github.com/bacpop/mandrake/actions/runs/7277716604/job/19830349056), or a local installation problem - will see what the CI outcomes are. Hence the slightly early-stage PR, sorry!