### PR TITLE
Updates to DBSCAN fitting

### DIFF
--- a/PopPUNK/__init__.py
+++ b/PopPUNK/__init__.py
@@ -3,7 +3,7 @@
 
 '''PopPUNK (POPulation Partitioning Using Nucleotide Kmers)'''
 
-__version__ = '2.6.3'
+__version__ = '2.6.4'
 
 # Minimum sketchlib version
 SKETCHLIB_MAJOR = 2

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -593,6 +593,7 @@ def main():
 
         # end here if not assigning data
         if args.for_refine:
+            sys.stderr.write('Initial model fit complete; points will be assigned when this model is refined\nusing "--fit-model refine"\n')
             sys.exit(0)
 
         #******************************#

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -122,8 +122,8 @@ def get_options():
                             help='Number of pairwise distances in each assignment batch [default = 5000]',
                             type=int,
                             default=5000)
-    modelGroup.add_argument('--no-assign',
-                            help='Fit the model without assigning all points (only applies to BGMM and DBSCAN models)',
+    modelGroup.add_argument('--for-refine',
+                            help='Fit a BGMM or DBSCAN model without assigning all points to initialise a refined model',
                             default=False,
                             action='store_true')
     modelGroup.add_argument('--K',
@@ -518,7 +518,7 @@ def main():
                 model = DBSCANFit(output,
                                   max_samples = args.model_subsample,
                                   max_batch_size = args.assign_subsample,
-                                  assign_points = not args.no_assign)
+                                  assign_points = not args.for_refine)
                 model.set_threads(args.threads)
                 assignments = model.fit(distMat,
                                         args.D,
@@ -529,7 +529,7 @@ def main():
                 model = BGMMFit(output,
                                 max_samples = args.model_subsample,
                                 max_batch_size = args.assign_subsample,
-                                assign_points = not args.no_assign)
+                                assign_points = not args.for_refine)
                 model.set_threads(args.threads)
                 assignments = model.fit(distMat,
                                         args.K)
@@ -592,7 +592,7 @@ def main():
             assignments = model.assign(distMat)
 
         # end here if not assigning data
-        if args.no_assign:
+        if args.for_refine:
             sys.exit(0)
 
         #******************************#

--- a/PopPUNK/__main__.py
+++ b/PopPUNK/__main__.py
@@ -114,11 +114,34 @@ def get_options():
 
     # model fitting
     modelGroup = parser.add_argument_group('Model fit options')
-    modelGroup.add_argument('--K', help='Maximum number of mixture components [default = 2]', type=int, default=2)
-    modelGroup.add_argument('--D', help='Maximum number of clusters in DBSCAN fitting [default = 100]', type=int, default=100)
-    modelGroup.add_argument('--min-cluster-prop', help='Minimum proportion of points in a cluster '
-                                                        'in DBSCAN fitting [default = 0.0001]', type=float, default=0.0001)
-    modelGroup.add_argument('--threshold', help='Cutoff if using --fit-model threshold', type=float)
+    modelGroup.add_argument('--model-subsample',
+                            help='Number of pairwise distances used to fit model [default = 100000]',
+                            type=int,
+                            default=100000)
+    modelGroup.add_argument('--assign-subsample',
+                            help='Number of pairwise distances in each assignment batch [default = 5000]',
+                            type=int,
+                            default=5000)
+    modelGroup.add_argument('--no-assign',
+                            help='Fit the model without assigning all points (only applies to BGMM and DBSCAN models)',
+                            default=False,
+                            action='store_true')
+    modelGroup.add_argument('--K',
+                            help='Maximum number of mixture components [default = 2]',
+                            type=int,
+                            default=2)
+    modelGroup.add_argument('--D',
+                            help='Maximum number of clusters in DBSCAN fitting [default = 100]',
+                            type=int,
+                            default=100)
+    modelGroup.add_argument('--min-cluster-prop',
+                            help='Minimum proportion of points in a cluster '
+                                 'in DBSCAN fitting [default = 0.0001]',
+                            type=float,
+                            default=0.0001)
+    modelGroup.add_argument('--threshold',
+                            help='Cutoff if using --fit-model threshold',
+                            type=float)
 
     # model refinement
     refinementGroup = parser.add_argument_group('Refine model options')
@@ -180,6 +203,7 @@ def get_options():
     other.add_argument('--threads', default=1, type=int, help='Number of threads to use [default = 1]')
     other.add_argument('--gpu-sketch', default=False, action='store_true', help='Use a GPU when calculating sketches (read data only) [default = False]')
     other.add_argument('--gpu-dist', default=False, action='store_true', help='Use a GPU when calculating distances [default = False]')
+    other.add_argument('--gpu-model', default=False, action='store_true', help='Use a GPU when fitting a model [default = False]')
     other.add_argument('--gpu-graph', default=False, action='store_true', help='Use a GPU when calculating networks [default = False]')
     other.add_argument('--deviceid', default=0, type=int, help='CUDA device ID, if using GPU [default = 0]')
     other.add_argument('--no-plot', help='Switch off model plotting, which can be slow for large datasets',
@@ -491,14 +515,24 @@ def main():
         if args.fit_model:
             # Run DBSCAN model
             if args.fit_model == "dbscan":
-                model = DBSCANFit(output)
+                model = DBSCANFit(output,
+                                  max_samples = args.model_subsample,
+                                  max_batch_size = args.assign_subsample,
+                                  assign_points = not args.no_assign)
                 model.set_threads(args.threads)
-                assignments = model.fit(distMat, args.D, args.min_cluster_prop)
+                assignments = model.fit(distMat,
+                                        args.D,
+                                        args.min_cluster_prop,
+                                        args.gpu_model)
             # Run Gaussian model
             elif args.fit_model == "bgmm":
-                model = BGMMFit(output)
+                model = BGMMFit(output,
+                                max_samples = args.model_subsample,
+                                max_batch_size = args.assign_subsample,
+                                assign_points = not args.no_assign)
                 model.set_threads(args.threads)
-                assignments = model.fit(distMat, args.K)
+                assignments = model.fit(distMat,
+                                        args.K)
             elif args.fit_model == "refine":
                 new_model = RefineFit(output)
                 new_model.set_threads(args.threads)
@@ -556,6 +590,10 @@ def main():
         # use model
         else:
             assignments = model.assign(distMat)
+
+        # end here if not assigning data
+        if args.no_assign:
+            sys.exit(0)
 
         #******************************#
         #*                            *#

--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -410,7 +410,7 @@ def assign_query_hdf5(dbFuncs,
 
     # Only proceed with a fully-fitted model
     if not model.fitted or (hasattr(model,'assign_points') and model.assign_points == False):
-        sys.stderr.write('Cannot assign points with an incompletely-fitted model\n')
+        sys.stderr.write('Cannot assign points with an incompletely-fitted model\nPlease refine this initial fit with "--fit-model refine"\n')
         sys.exit(1)
 
     # Set directories of previous fit

--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -408,6 +408,11 @@ def assign_query_hdf5(dbFuncs,
         raise RuntimeError("lineage models cannot be used with --serial")
     model.set_threads(threads)
 
+    # Only proceed with a fully-fitted model
+    if not model.fitted or (hasattr(model,'assign_points') and model.assign_points == False):
+        sys.stderr.write('Cannot assign points with an incompletely-fitted model\n')
+        sys.exit(1)
+
     # Set directories of previous fit
     if previous_clustering is not None:
         prev_clustering = previous_clustering

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -513,7 +513,7 @@ class DBSCANFit(ClusterFit):
 
         # DBSCAN parameters
         cache_out = "./" + self.outPrefix + "_cache"
-        min_samples = min(max(int(min_cluster_prop * self.subsampled_X.shape[0]), 10),1023)
+        min_samples = min(int(min_cluster_prop * self.subsampled_X.shape[0]), 1023)
         min_cluster_size = max(int(0.01 * self.subsampled_X.shape[0]), 10)
 
         # Check on initialisation of GPU libraries and memory

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -39,6 +39,7 @@ try:
     import cupy as cp
     from numba import cuda
     import rmm
+    from cuml import cluster
 except ImportError:
     pass
 
@@ -289,16 +290,16 @@ class BGMMFit(ClusterFit):
             The output prefix used for reading/writing
         max_samples (int)
             The number of subsamples to fit the model to
-
             (default = 100000)
     '''
 
-    def __init__(self, outPrefix, max_samples = 50000):
+    def __init__(self, outPrefix, max_samples = 100000, max_batch_size = 100000, assign_points = True):
         ClusterFit.__init__(self, outPrefix)
         self.type = 'bgmm'
         self.preprocess = True
         self.max_samples = max_samples
-
+        self.max_batch_size = max_batch_size
+        self.assign_points = assign_points
 
     def fit(self, X, max_components):
         '''Extends :func:`~ClusterFit.fit`
@@ -325,8 +326,12 @@ class BGMMFit(ClusterFit):
         self.means = self.dpgmm.means_
         self.covariances = self.dpgmm.covariances_
         self.fitted = True
-
-        y = self.assign(X)
+        
+        # Allow for partial fitting that only assigns the subsample not the full set
+        if self.assign_points:
+            y = self.assign(X, max_batch_size = self.max_batch_size)
+        else:
+            y = self.assign(self.subsampled_X, max_batch_size = self.max_batch_size)
         self.within_label = findWithinLabel(self.means, y)
         self.between_label = findWithinLabel(self.means, y, 1)
         return y
@@ -384,7 +389,7 @@ class BGMMFit(ClusterFit):
         if not hasattr(self, 'subsampled_X'):
             self.subsampled_X = utils.shuffle(X, random_state=random.randint(1,10000))[0:self.max_samples,]
 
-        y_subsample = self.assign(self.subsampled_X, values=True, progress=False)
+        y_subsample = self.assign(self.subsampled_X, max_batch_size = self.max_batch_size, values=True, progress=False)
         avg_entropy = np.mean(np.apply_along_axis(stats.entropy, 1,
                                                   y_subsample))
         used_components = np.unique(y).size
@@ -402,7 +407,7 @@ class BGMMFit(ClusterFit):
         plot_contours(self, y, title + " assignment boundary", outfile + "_contours")
 
 
-    def assign(self, X, values = False, progress=True):
+    def assign(self, X, max_batch_size = 100000, values = False, progress=True):
         '''Assign the clustering of new samples using :func:`~PopPUNK.bgmm.assign_samples`
 
         Args:
@@ -410,8 +415,8 @@ class BGMMFit(ClusterFit):
                 Core and accessory distances
             values (bool)
                 Return the responsibilities of assignment rather than most likely cluster
-            num_processes (int)
-                Number of threads to use
+            max_batch_size (int)
+                Size of batches to be assigned
             progress (bool)
                 Show progress bar
 
@@ -430,7 +435,7 @@ class BGMMFit(ClusterFit):
                 y = np.zeros((X.shape[0], len(self.weights)), dtype=X.dtype)
             else:
                 y = np.zeros(X.shape[0], dtype=int)
-            block_size = 100000
+            block_size = max_batch_size
             with SharedMemoryManager() as smm:
                 shm_X = smm.SharedMemory(size = X.nbytes)
                 X_shared_array = np.ndarray(X.shape, dtype = X.dtype, buffer = shm_X.buf)
@@ -469,18 +474,19 @@ class DBSCANFit(ClusterFit):
             The output prefix used for reading/writing
         max_samples (int)
             The number of subsamples to fit the model to
-
             (default = 100000)
     '''
 
-    def __init__(self, outPrefix, max_samples = 100000):
+    def __init__(self, outPrefix, use_gpu = False, max_batch_size = 5000, max_samples = 100000, assign_points = True):
         ClusterFit.__init__(self, outPrefix)
         self.type = 'dbscan'
         self.preprocess = True
+        self.max_batch_size = max_batch_size
         self.max_samples = max_samples
+        self.assign_points = assign_points
+        self.use_gpu = use_gpu # Updated below
 
-
-    def fit(self, X, max_num_clusters, min_cluster_prop):
+    def fit(self, X, max_num_clusters, min_cluster_prop, use_gpu = False):
         '''Extends :func:`~ClusterFit.fit`
 
         Fits the distances with HDBSCAN and returns assignments by calling
@@ -496,6 +502,8 @@ class DBSCANFit(ClusterFit):
                 Maximum number of clusters in DBSCAN fitting
             min_cluster_prop (float)
                 Minimum proportion of points in a cluster in DBSCAN fitting
+            use_gpu (bool)
+                Whether GPU algorithms should be used in DBSCAN fitting
 
         Returns:
             y (numpy.array)
@@ -505,32 +513,78 @@ class DBSCANFit(ClusterFit):
 
         # DBSCAN parameters
         cache_out = "./" + self.outPrefix + "_cache"
-        min_samples = max(int(min_cluster_prop * self.subsampled_X.shape[0]), 10)
+        min_samples = min(max(int(min_cluster_prop * self.subsampled_X.shape[0]), 10),1023)
         min_cluster_size = max(int(0.01 * self.subsampled_X.shape[0]), 10)
+
+        # Check on initialisation of GPU libraries and memory
+        # Convert to cupy if using GPU to avoid implicit numpy conversion below
+        if use_gpu:
+            try:
+                import cudf
+                from cuml import cluster
+                import cupy as cp
+                gpu_lib = True
+            except ImportError as e:
+                gpu_lib = False
+            # check on GPU
+            use_gpu = check_and_set_gpu(use_gpu,
+                                gpu_lib,
+                                quit_on_fail = True)
+            if use_gpu:
+                self.use_gpu = True
+                self.subsampled_X = cp.asarray(self.subsampled_X)
+            else:
+                self.use_gpu = False
 
         indistinct_clustering = True
         while indistinct_clustering and min_cluster_size >= min_samples and min_samples >= 10:
-            self.hdb, self.labels, self.n_clusters = fitDbScan(self.subsampled_X, min_samples, min_cluster_size, cache_out)
+            # Fit model
+            self.hdb, self.labels, self.n_clusters = fitDbScan(self.subsampled_X,
+                                                                min_samples,
+                                                                min_cluster_size,
+                                                                cache_out,
+                                                                use_gpu = use_gpu)
             self.fitted = True # needed for predict
 
             # Test whether model fit contains distinct clusters
             if self.n_clusters > 1 and self.n_clusters <= max_num_clusters:
-                # get within strain cluster
-                self.max_cluster_num = self.labels.max()
-                self.cluster_means = np.full((self.n_clusters,2),0.0,dtype=float)
-                self.cluster_mins = np.full((self.n_clusters,2),0.0,dtype=float)
-                self.cluster_maxs = np.full((self.n_clusters,2),0.0,dtype=float)
+            
+              if use_gpu:
+                  # get within strain cluster
+                  self.max_cluster_num = int(self.labels.max())
+                  self.cluster_means = cp.full((self.n_clusters,2),0.0,dtype=float)
+                  self.cluster_mins = cp.full((self.n_clusters,2),0.0,dtype=float)
+                  self.cluster_maxs = cp.full((self.n_clusters,2),0.0,dtype=float)
 
-                for i in range(self.max_cluster_num+1):
-                    self.cluster_means[i,] = [np.mean(self.subsampled_X[self.labels==i,0]),np.mean(self.subsampled_X[self.labels==i,1])]
-                    self.cluster_mins[i,] = [np.min(self.subsampled_X[self.labels==i,0]),np.min(self.subsampled_X[self.labels==i,1])]
-                    self.cluster_maxs[i,] = [np.max(self.subsampled_X[self.labels==i,0]),np.max(self.subsampled_X[self.labels==i,1])]
+                  for i in range(self.max_cluster_num+1):
+                      labelled_rows = cp.where(self.labels==i,True,False)
+                      self.cluster_means[cp.array(i),] = [cp.mean(self.subsampled_X[labelled_rows,cp.array([0])]),cp.mean(self.subsampled_X[labelled_rows,cp.array([1])])]
+                      self.cluster_mins[cp.array(i),] = [cp.min(self.subsampled_X[labelled_rows,cp.array([0])]),cp.min(self.subsampled_X[labelled_rows,cp.array([1])])]
+                      self.cluster_maxs[cp.array(i),] = [cp.max(self.subsampled_X[labelled_rows,cp.array([0])]),cp.max(self.subsampled_X[labelled_rows,cp.array([1])])]
+                  
+              else:
+                  # get within strain cluster
+                  self.max_cluster_num = self.labels.max()
+                  self.cluster_means = np.full((self.n_clusters,2),0.0,dtype=float)
+                  self.cluster_mins = np.full((self.n_clusters,2),0.0,dtype=float)
+                  self.cluster_maxs = np.full((self.n_clusters,2),0.0,dtype=float)
 
-                y = self.assign(self.subsampled_X, no_scale=True, progress=False)
-                self.within_label = findWithinLabel(self.cluster_means, y)
-                self.between_label = findBetweenLabel(y, self.within_label)
+                  for i in range(self.max_cluster_num+1):
+                      self.cluster_means[i,] = [np.mean(self.subsampled_X[self.labels==i,0]),np.mean(self.subsampled_X[self.labels==i,1])]
+                      self.cluster_mins[i,] = [np.min(self.subsampled_X[self.labels==i,0]),np.min(self.subsampled_X[self.labels==i,1])]
+                      self.cluster_maxs[i,] = [np.max(self.subsampled_X[self.labels==i,0]),np.max(self.subsampled_X[self.labels==i,1])]
 
-                indistinct_clustering = evaluate_dbscan_clusters(self)
+              # Run assignment
+              y = self.assign(self.subsampled_X,
+                              no_scale=True,
+                              progress=False,
+                              max_batch_size = self.subsampled_X.shape[0],
+                              use_gpu = use_gpu)
+              
+              # Evaluate clustering
+              self.within_label = findWithinLabel(self.cluster_means, y)
+              self.between_label = findBetweenLabel(y, self.within_label)
+              indistinct_clustering = evaluate_dbscan_clusters(self)
 
             # Alter minimum cluster size criterion
             if min_cluster_size < min_samples / 2:
@@ -542,10 +596,15 @@ class DBSCANFit(ClusterFit):
             self.fitted = False
             sys.stderr.write("Failed to find distinct clusters in this dataset\n")
             sys.exit(1)
-        else:
+        elif not use_gpu:
             shutil.rmtree(cache_out)
 
-        y = self.assign(X)
+        # Allow for partial fitting that only assigns the subsample not the full set
+        if self.assign_points:
+            y = self.assign(X, max_batch_size = self.max_batch_size, use_gpu = use_gpu)
+        else:
+            y = self.assign(self.subsampled_X, max_batch_size = self.max_batch_size, use_gpu = use_gpu)
+
         return y
 
 
@@ -561,7 +620,9 @@ class DBSCANFit(ClusterFit):
              means=self.cluster_means,
              maxs=self.cluster_maxs,
              mins=self.cluster_mins,
-             scale=self.scale)
+             scale=self.scale,
+             assign_points = self.assign_points,
+             use_gpu=self.use_gpu)
             with open(self.outPrefix + "/" + os.path.basename(self.outPrefix) + '_fit.pkl', 'wb') as pickle_file:
                 pickle.dump([self.hdb, self.type], pickle_file)
 
@@ -584,6 +645,17 @@ class DBSCANFit(ClusterFit):
         self.cluster_means = fit_npz['means']
         self.cluster_maxs = fit_npz['maxs']
         self.cluster_mins = fit_npz['mins']
+        self.scale = fit_npz['scale']
+        if 'use_gpu' in fit_npz.keys():
+            self.use_gpu = fit_npz['use_gpu']
+        else:
+            # Default for backwards compatibility
+            self.use_gpu = False
+        if 'assign_points' in fit_npz.keys():
+            self.assign_points = fit_npz['assign_points']
+        else:
+            # Default for backwards compatibility
+            self.assign_points = True
         self.fitted = True
 
 
@@ -614,26 +686,40 @@ class DBSCANFit(ClusterFit):
             sys.stderr.write("\t" + str(centre) + "\n")
         sys.stderr.write("\n")
 
+        # Harmonise scales
+        if self.use_gpu:
+            import cupy as cp
+            self.scale = cp.asarray(self.scale)
+
         plot_dbscan_results(self.subsampled_X * self.scale,
-                            self.assign(self.subsampled_X, no_scale=True, progress=False),
+                            self.assign(self.subsampled_X,
+                                        max_batch_size = self.max_batch_size,
+                                        no_scale=True,
+                                        progress=False,
+                                        use_gpu=self.use_gpu),
                             self.n_clusters,
-                            self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan")
+                            self.outPrefix + "/" + os.path.basename(self.outPrefix) + "_dbscan",
+                            self.use_gpu)
 
 
-    def assign(self, X, no_scale = False, progress = True):
+    def assign(self, X, no_scale = False, progress = True, max_batch_size = 5000, use_gpu = False):
         '''Assign the clustering of new samples using :func:`~PopPUNK.dbscan.assign_samples_dbscan`
 
         Args:
-            X (numpy.array)
+            X (numpy.array or cupy.array)
                 Core and accessory distances
             no_scale (bool)
                 Do not scale X
-
                 [default = False]
             progress (bool)
                 Show progress bar
-
                 [default = True]
+            max_batch_size (int)
+                Batch size used for assignments
+                [default = 5000]
+            use_gpu (bool)
+                Use GPU-enabled algorithms for clustering
+                [default = False]
         Returns:
             y (numpy.array)
                 Cluster assignments by samples
@@ -647,35 +733,50 @@ class DBSCANFit(ClusterFit):
                 scale = self.scale
             if progress:
                 sys.stderr.write("Assigning distances with DBSCAN model\n")
+            
+            # Set block size
+            block_size = max_batch_size
+            
+            if use_gpu:
+              y = np.zeros(X.shape[0], dtype=int)
+              n_blocks = (X.shape[0] - 1) // block_size + 1
+              for block in range(n_blocks):
+                  start_index = block*block_size
+                  end_index = min((block+1)*block_size-1,X.shape[0])
+                  sys.stderr.write("Processing rows " + str(start_index) + " to " + str(end_index) + "\n")
+                  # cuml v24.02 always returns numpy therefore make conversion explicit
+                  y[start_index:end_index], y_probabilities = cluster.hdbscan.approximate_predict(self.hdb,
+                                                                                                  X[start_index:end_index,],
+                                                                                                  convert_dtype = True)
+                  del y_probabilities
+            else:
+              y = np.zeros(X.shape[0], dtype=int)
+              n_blocks = (X.shape[0] - 1) // block_size + 1
+              with SharedMemoryManager() as smm:
+                  shm_X = smm.SharedMemory(size = X.nbytes)
+                  X_shared_array = np.ndarray(X.shape, dtype = X.dtype, buffer = shm_X.buf)
+                  X_shared_array[:] = X[:]
+                  X_shared = NumpyShared(name = shm_X.name, shape = X.shape, dtype = X.dtype)
 
-            y = np.zeros(X.shape[0], dtype=int)
-            block_size = 5000
-            n_blocks = (X.shape[0] - 1) // block_size + 1
-            with SharedMemoryManager() as smm:
-                shm_X = smm.SharedMemory(size = X.nbytes)
-                X_shared_array = np.ndarray(X.shape, dtype = X.dtype, buffer = shm_X.buf)
-                X_shared_array[:] = X[:]
-                X_shared = NumpyShared(name = shm_X.name, shape = X.shape, dtype = X.dtype)
+                  shm_y = smm.SharedMemory(size = y.nbytes)
+                  y_shared_array = np.ndarray(y.shape, dtype = y.dtype, buffer = shm_y.buf)
+                  y_shared_array[:] = y[:]
+                  y_shared = NumpyShared(name = shm_y.name, shape = y.shape, dtype = y.dtype)
 
-                shm_y = smm.SharedMemory(size = y.nbytes)
-                y_shared_array = np.ndarray(y.shape, dtype = y.dtype, buffer = shm_y.buf)
-                y_shared_array[:] = y[:]
-                y_shared = NumpyShared(name = shm_y.name, shape = y.shape, dtype = y.dtype)
+                  tqdm.set_lock(RLock())
+                  process_map(partial(assign_samples,
+                              X = X_shared,
+                              y = y_shared,
+                              model = self,
+                              scale = scale,
+                              chunk_size = block_size,
+                              values = False),
+                      range(n_blocks),
+                      max_workers=self.threads,
+                      chunksize=min(10, max(1, n_blocks // self.threads)),
+                      disable=(progress == False))
 
-                tqdm.set_lock(RLock())
-                process_map(partial(assign_samples,
-                            X = X_shared,
-                            y = y_shared,
-                            model = self,
-                            scale = scale,
-                            chunk_size = block_size,
-                            values = False),
-                    range(n_blocks),
-                    max_workers=self.threads,
-                    chunksize=min(10, max(1, n_blocks // self.threads)),
-                    disable=(progress == False))
-
-                y[:] = y_shared_array[:]
+                  y[:] = y_shared_array[:]
 
         return y
 
@@ -699,6 +800,7 @@ class RefineFit(ClusterFit):
         self.slope = 2
         self.threshold = False
         self.unconstrained = False
+        self.assign_points = True
 
     def fit(self, X, sample_names, model, max_move, min_move, startFile = None, indiv_refine = False,
             unconstrained = False, multi_boundary = 0, score_idx = 0, no_local = False,

--- a/PopPUNK/models.py
+++ b/PopPUNK/models.py
@@ -513,7 +513,8 @@ class DBSCANFit(ClusterFit):
 
         # DBSCAN parameters
         cache_out = "./" + self.outPrefix + "_cache"
-        min_samples = min(int(min_cluster_prop * self.subsampled_X.shape[0]), 1023)
+        min_samples = max(int(min_cluster_prop * self.subsampled_X.shape[0]), 10) # do not allow clusters of < 10 points
+        min_samples = min(min_samples,1023) # do not allow clusters to require more than 1023 points at the start
         min_cluster_size = max(int(0.01 * self.subsampled_X.shape[0]), 10)
 
         # Check on initialisation of GPU libraries and memory

--- a/PopPUNK/plot.py
+++ b/PopPUNK/plot.py
@@ -182,7 +182,7 @@ def plot_results(X, Y, means, covariances, scale, title, out_prefix):
     plt.savefig(out_prefix + ".png")
     plt.close()
 
-def plot_dbscan_results(X, y, n_clusters, out_prefix):
+def plot_dbscan_results(X, y, n_clusters, out_prefix, use_gpu):
     """Draw a scatter plot (png) to show the DBSCAN model fit
 
     A scatter plot of core and accessory distances, coloured by component
@@ -197,7 +197,15 @@ def plot_dbscan_results(X, y, n_clusters, out_prefix):
             Number of clusters used (excluding noise)
         out_prefix (str)
             Prefix for output file (.png will be appended)
+        use_gpu (bool)
+            Whether model was fitted with GPU-enabled code
     """
+    # Convert data if from GPU
+    if use_gpu:
+        # Convert to numpy for plotting
+        import cupy as cp
+        X = cp.asnumpy(X)
+    
     # Black removed and is used for noise instead.
     unique_labels = set(y)
     colours = [plt.cm.Spectral(each) for each in np.linspace(0, 1, len(unique_labels))]  # changed to work with two clusters

--- a/PopPUNK/refine.py
+++ b/PopPUNK/refine.py
@@ -42,7 +42,7 @@ from .__main__ import betweenness_sample_default
 from .network import construct_network_from_df, printClusters
 from .network import construct_network_from_edge_list
 from .network import networkSummary
-from .network import add_self_loop
+from .network import generate_cugraph
 
 from .utils import transformLine
 from .utils import decisionBoundary

--- a/PopPUNK/utils.py
+++ b/PopPUNK/utils.py
@@ -8,6 +8,7 @@ import os
 import sys
 # additional
 import pickle
+import multiprocessing
 from collections import defaultdict
 from itertools import chain
 from tempfile import mkstemp
@@ -572,11 +573,12 @@ def check_and_set_gpu(use_gpu, gpu_lib, quit_on_fail = False):
 
     # Set memory management for large networks
     if use_gpu:
+        multiprocessing.set_start_method('spawn', force=True)
         rmm.reinitialize(managed_memory=True)
         if "cupy" in sys.modules:
-            cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+            cupy.cuda.set_allocator(rmm.allocators.cupy.rmm_cupy_allocator)
         if "cuda" in sys.modules:
-            cuda.set_memory_manager(rmm.RMMNumbaManager)
+            cuda.set_memory_manager(rmm.allocators.numba.RMMNumbaManager)
         assert(rmm.is_initialized())
 
     return use_gpu

--- a/docs/gpu.rst
+++ b/docs/gpu.rst
@@ -111,4 +111,15 @@ Using a GPU
 By default, PopPUNK will use not use GPUs. To use them, you will need to add
 the flag ``--gpu-sketch`` (when constructing or querying a database using reads),
 ``--gpu-dist`` (when constructing or querying a database from assemblies or reads),
-or ``--gpu-graph`` (when querying or visualising a database, or fitting a model).
+``--gpu-model`` (when fitting a DBSCAN model on the GPU), or ``--gpu-graph``
+(when querying or visualising a database, or fitting a model).
+
+Note that fitting a model with a GPU is fast, even with a large subsample of points,
+but may be limited by the memory of the GPU device. Therefore it is recommended that
+either the model is only fitted to a subsample of points, resulting in an incomplete
+model fit that must then be refined before use (option ``--for-refine``), or that
+the transfer of data between CPU and GPU is optimised using the ``--assign-subsample``
+variable. Larger values of ``--assign-subsample`` will result in fewer batches being
+transferred to the GPU memory, speeding up the process, but also increasing the risks
+that your device will run out of memory, particularly if a large, complex model object
+is already being stored on the device.

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -31,6 +31,7 @@ subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model bgmm --ref-db exa
 
 #fit dbscan
 sys.stderr.write("Running DBSCAN model fit (--fit-model dbscan)\n")
+subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model dbscan --ref-db example_db --output example_dbscan --overwrite --graph-weights --for-refine", shell=True, check=True)
 subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model dbscan --ref-db example_db --output example_dbscan --overwrite --graph-weights", shell=True, check=True)
 
 #refine model with GMM

--- a/test/test-gpu.py
+++ b/test/test-gpu.py
@@ -31,6 +31,10 @@ subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model bgmm --ref-db exa
 
 #fit dbscan
 sys.stderr.write("Running DBSCAN model fit (--fit-model dbscan)\n")
+subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model dbscan --ref-db example_db --output example_dbscan --overwrite --gpu-graph --gpu-model", shell=True, check=True)
+subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model dbscan --ref-db example_db --output example_dbscan --overwrite --gpu-graph --gpu-model --for-refine", shell=True, check=True)
+subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model dbscan --ref-db example_db --output example_dbscan --overwrite --gpu-graph --gpu-model --assign-subsample 1000", shell=True, check=True)
+subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model dbscan --ref-db example_db --output example_dbscan --overwrite --gpu-graph --gpu-model --model-subsample 5000", shell=True, check=True)
 subprocess.run(python_cmd + " ../poppunk-runner.py --fit-model dbscan --ref-db example_db --output example_dbscan --overwrite --graph-weights --gpu-graph", shell=True, check=True)
 
 #refine model with GMM


### PR DESCRIPTION
Motivated by trying to fit a DBSCAN model to a large dataset. Problems were:

- indistinct clustering criterion; this was very strict (separation between within and between strain cluster on both axes required), rejecting some sensible fits; now relaxed (separation only required on one axis) - let me know if you think the stricter option should still be available though a flag, or if you're happy with change across the board
- slow fitting to large datasets; implemented GPU version of DBSCAN, which is fast; the problem is then assigning all distances, which is slow, because the model takes up a lot of GPU memory, and copying over batches of distances into the variable amount of remaining GPU memory (customisable with the new `--assign-subsample` option) negates the speed up of the initial fit
- slow assignment of distances to model fit; this is inefficient, as we typically don't use the assignments of points to the initial model fit, and it takes ages on a large dataset. Instead I have added a `--no-assign` flag, which skips the assignment, labels the model appropriately, and allows a refined model fit that then assigns all points

If you approve these changes conceptually, then I'll add tests and docs. 