### PR TITLE
Avoid overwriting external clustering in visualise script

### DIFF
--- a/PopPUNK/visualise.py
+++ b/PopPUNK/visualise.py
@@ -378,6 +378,20 @@ def generate_visualisations(query_db,
     #*                                *#
     #**********************************#
 
+    # identify existing model and cluster files
+    if model_dir is not None:
+        model_prefix = model_dir
+    else:
+        model_prefix = ref_db
+    try:
+        model_file = os.path.join(model_prefix, os.path.basename(model_prefix))
+        model = loadClusterFit(model_file + '_fit.pkl',
+                               model_file + '_fit.npz')
+        model.set_threads(threads)
+    except FileNotFoundError:
+        sys.stderr.write('Unable to locate previous model fit in ' + model_prefix + '\n')
+        sys.exit(1)
+
     # Either use strain definitions, lineage assignments or external clustering
     isolateClustering = {}
     # Use external clustering if specified
@@ -388,20 +402,6 @@ def generate_visualisations(query_db,
                                                    return_dict = True)
 
     else:
-
-        # identify existing model and cluster files
-        if model_dir is not None:
-            model_prefix = model_dir
-        else:
-            model_prefix = ref_db
-        try:
-            model_file = os.path.join(model_prefix, os.path.basename(model_prefix))
-            model = loadClusterFit(model_file + '_fit.pkl',
-                                   model_file + '_fit.npz')
-            model.set_threads(threads)
-        except FileNotFoundError:
-            sys.stderr.write('Unable to locate previous model fit in ' + model_prefix + '\n')
-            sys.exit(1)
 
         # Load previous clusters
         if previous_clustering is not None:

--- a/PopPUNK/visualise.py
+++ b/PopPUNK/visualise.py
@@ -387,39 +387,41 @@ def generate_visualisations(query_db,
                                                    mode = 'external',
                                                    return_dict = True)
 
-    # identify existing model and cluster files
-    if model_dir is not None:
-        model_prefix = model_dir
     else:
-        model_prefix = ref_db
-    try:
-        model_file = os.path.join(model_prefix, os.path.basename(model_prefix))
-        model = loadClusterFit(model_file + '_fit.pkl',
-                               model_file + '_fit.npz')
-        model.set_threads(threads)
-    except FileNotFoundError:
-        sys.stderr.write('Unable to locate previous model fit in ' + model_prefix + '\n')
-        sys.exit(1)
 
-    # Load previous clusters
-    if previous_clustering is not None:
-        prev_clustering = previous_clustering
-        mode = "clusters"
-        suffix = "_clusters.csv"
-        if prev_clustering.endswith('_lineages.csv'):
-            mode = "lineages"
-            suffix = "_lineages.csv"
-    else:
-        # Identify type of clustering based on model
-        mode = "clusters"
-        suffix = "_clusters.csv"
-        if model.type == "lineage":
-            mode = "lineages"
-            suffix = "_lineages.csv"
-        prev_clustering = os.path.join(model_prefix, os.path.basename(model_prefix) + suffix)
-    isolateClustering = readIsolateTypeFromCsv(prev_clustering,
-                                               mode = mode,
-                                               return_dict = True)
+        # identify existing model and cluster files
+        if model_dir is not None:
+            model_prefix = model_dir
+        else:
+            model_prefix = ref_db
+        try:
+            model_file = os.path.join(model_prefix, os.path.basename(model_prefix))
+            model = loadClusterFit(model_file + '_fit.pkl',
+                                   model_file + '_fit.npz')
+            model.set_threads(threads)
+        except FileNotFoundError:
+            sys.stderr.write('Unable to locate previous model fit in ' + model_prefix + '\n')
+            sys.exit(1)
+
+        # Load previous clusters
+        if previous_clustering is not None:
+            cluster_file = previous_clustering
+            mode = "clusters"
+            suffix = "_clusters.csv"
+            if cluster_file.endswith('_lineages.csv'):
+                mode = "lineages"
+                suffix = "_lineages.csv"
+        else:
+            # Identify type of clustering based on model
+            mode = "clusters"
+            suffix = "_clusters.csv"
+            if model.type == "lineage":
+                mode = "lineages"
+                suffix = "_lineages.csv"
+            cluster_file = os.path.join(model_prefix, os.path.basename(model_prefix) + suffix)
+        isolateClustering = readIsolateTypeFromCsv(cluster_file,
+                                                   mode = mode,
+                                                   return_dict = True)
 
     # Add individual refinement clusters if they exist
     if model.indiv_fitted:
@@ -469,7 +471,7 @@ def generate_visualisations(query_db,
                         if display_cluster not in isolateClustering.keys():
                             clustering_name = list(isolateClustering.keys())[0]
                             sys.stderr.write('Unable to find clustering column ' + display_cluster + ' in file ' +
-                                            prev_clustering + '; instead using ' + clustering_name + '\n')
+                                            cluster_file + '; instead using ' + clustering_name + '\n')
                         else:
                             clustering_name = display_cluster
                     else:

--- a/test/clean_test.py
+++ b/test/clean_test.py
@@ -45,7 +45,9 @@ outputDirs = [
     "batch2",
     "batch3",
     "batch12",
-    "batch123"
+    "batch123",
+    "strain_1_lineage_db",
+    "strain_2_lineage_db"
 ]
 for outDir in outputDirs:
     deleteDir(outDir)


### PR DESCRIPTION
@EmmaLRussell pointed out beebop is being scuppered by the overwriting of external clustering in the visualisation code - I think this fixes the problem and at least adds a test for running this mode of visualisation, although we might need to check it actually outputs the correct clustering at some point. But if we can release to conda we can get the new version of beebop out soon.