### PR TITLE
Move call of sketchlibAssemblyQC in query assign

### DIFF
--- a/PopPUNK/__init__.py
+++ b/PopPUNK/__init__.py
@@ -3,7 +3,7 @@
 
 '''PopPUNK (POPulation Partitioning Using Nucleotide Kmers)'''
 
-__version__ = '2.6.6'
+__version__ = '2.6.7'
 
 # Minimum sketchlib version
 SKETCHLIB_MAJOR = 2


### PR DESCRIPTION
This PR moves sketchlibAssemblyQC call from `assign_query` to after `assign_query_hdf5` is called. This is so Beebop can utilise this function also and do quality check for the `--length-range` . If they fail qc it will be written to `qcreport.txt`.
 