### PR TITLE
Replaced deprecated 'rU' with 'r' to make this work on recent python

### DIFF
--- a/PopPUNK/utils.py
+++ b/PopPUNK/utils.py
@@ -422,7 +422,7 @@ def readRfile(rFile, oneSeq=False):
     """
     names = []
     sequences = []
-    with open(rFile, 'rU') as refFile:
+    with open(rFile, 'r') as refFile:
         for refLine in refFile:
             rFields = refLine.rstrip().split("\t")
             if len(rFields) < 2:


### PR DESCRIPTION
as per: https://docs.python.org/3/whatsnew/3.11.html#porting-to-python-3-11 'U' has deprecated since python 3.3: https://github.com/python/cpython/issues/81511
and as per: https://docs.python.org/3/library/functions.html, 'U' has been completely removed from Python 3.11 