### PR TITLE
Fix External Clusters csv being duplicated

### DIFF
--- a/.github/workflows/docs_pr.yml
+++ b/.github/workflows/docs_pr.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         docs-folder: "docs/"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: DocumentationHTML
         path: docs/_build/html/

--- a/PopPUNK/__init__.py
+++ b/PopPUNK/__init__.py
@@ -3,7 +3,7 @@
 
 '''PopPUNK (POPulation Partitioning Using Nucleotide Kmers)'''
 
-__version__ = '2.7.0'
+__version__ = '2.7.1'
 
 # Minimum sketchlib version
 SKETCHLIB_MAJOR = 2

--- a/PopPUNK/assign.py
+++ b/PopPUNK/assign.py
@@ -718,9 +718,9 @@ def assign_query_hdf5(dbFuncs,
                     cluster_f.write(",".join((sample, str(cluster))) + "\n")
                 cluster_f.close()
 
-            if external_clustering is not None:
-                printExternalClusters(isolateClustering, external_clustering,
-                                        output, rNames, printRef=False)
+                if external_clustering is not None:
+                    printExternalClusters(isolateClustering, external_clustering,
+                                            output, rNames, printRef=False)
 
         # Update DB as requested
         dists_out = output + "/" + os.path.basename(output) + ".dists"


### PR DESCRIPTION
This PR fixes issue where when assgin cluster and writing into the external_clusters.csv, it was duplicated and in the wrong location on the duplicate. 

The update V2.7.0 moved the call to `printExternalClusters` outside an `else` statement causing this duplicate. Thus the fix was to indent the call again


Also in docs_pr pipeline - actions/upload-artifact@v1 was deprecated and caused failure thus upgraded to actions/upload-artifact@v4