### PR TITLE
Add cstdint include for improved type support in Python bindings

### DIFF
--- a/src/python_bindings.cpp
+++ b/src/python_bindings.cpp
@@ -3,7 +3,7 @@
  * Python bindings for PopPUNK C++ functions
  *
  */
-
+#include <cstdint>
 // pybind11 headers
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>


### PR DESCRIPTION
Add #include <cstdint> , as was getting errors on beebop pipelines due to a combination of compiler / stdlib versions. This ensures these errors do not occur... 

Build fail example with error log: https://github.com/bacpop/beebop_py/actions/runs/12708281760/job/35424932695?pr=53